### PR TITLE
Cleanup obs service name and spec file

### DIFF
--- a/config/mash_obs.service
+++ b/config/mash_obs.service
@@ -5,7 +5,7 @@ Before=systemd-user-sessions.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/obs-service-2
+ExecStart=/usr/bin/mash-obs-service
 StandardOutput=null
 Restart=always
 

--- a/config/obs_config.yml
+++ b/config/obs_config.yml
@@ -1,3 +1,3 @@
 obs:
-  logfile: /var/log/obs_service.log
+  logfile: /var/log/mash_obs_service.log
   download_directory: /var/tmp/mash/images

--- a/package/mash-spec-template
+++ b/package/mash-spec-template
@@ -49,8 +49,8 @@ python setup.build.py build
 %install
 python setup.build.py install --prefix=%{_prefix} --root=%{buildroot}
 
-install -D -m 644 config/obs_result.service \
-    %{buildroot}%{_unitdir}/obs_result.service
+install -D -m 644 config/mash_obs.service \
+    %{buildroot}%{_unitdir}/mash_obs.service
 
 install -D -m 644 config/obs_config.yml \
     %{buildroot}%{_sysconfdir}/%{name}/obs_config.yml
@@ -65,8 +65,8 @@ install -D -m 644 config/logger_config.yml \
 %defattr(-,root,root,-)
 %{python_sitelib}/*
 %dir %{_sysconfdir}/%{name}
-%{_bindir}/obs-service-2
-%{_unitdir}/obs_result.service
+%{_bindir}/mash-obs-service
+%{_unitdir}/mash_obs.service
 %config(noreplace) %{_sysconfdir}/%{name}/obs_config.yml
 
 %{_bindir}/mash-logger-service

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,7 @@ config = {
     'packages': ['mash'],
     'entry_points': {
         'console_scripts': [
-            'obs-service-{0}=mash.services.obs_service:main'.format(
-                python_version
-            ),
+            'mash-obs-service=mash.services.obs_service:main',
             'mash-logger-service=mash.services.logger_service:main'
         ]
     },


### PR DESCRIPTION
Follow the naming conventions as implemented by
the logger service and use the mash prefix for
the unit file as well as don't use python version
information in the binary name