### PR TITLE
Add logger code to package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@
 
 graft mash/services
 graft mash/services/obs
+graft mash/services/logger
 graft package
 graft config
 


### PR DESCRIPTION
In order to actually package the logger service it needs to be part of the manifest