### PR TITLE
Update format of obs job log information

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -229,6 +229,7 @@ class OBSImageBuildResult(object):
 
     def _init_status(self):
         image_status = {
+            'job_id': self.job_id,
             'name': self.package,
             'job_status': 'prepared',
             'image_source': 'unknown',

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -132,10 +132,10 @@ class OBSImageBuildResultService(BaseService):
 
     def _log_listener(self):
         result = {
-            'obs_job_log': {}
+            'obs_job_log': []
         }
         for job_id, job in list(self.jobs.items()):
-            result['obs_job_log'][job_id] = job.get_image_status()
+            result['obs_job_log'].append(job.get_image_status())
         if self.last_log_result != result:
             self.log.info(self._json_message(result))
         self.last_log_result = copy.deepcopy(result)

--- a/test/unit/services_obs_build_result_test.py
+++ b/test/unit/services_obs_build_result_test.py
@@ -42,6 +42,7 @@ class TestOBSImageBuildResult(object):
         self.obs_result.conditions = [{'status': None}]
         self.obs_result.image_status = self.obs_result._init_status()
         assert self.obs_result.get_image_status() == {
+            'job_id': '815',
             'job_status': 'prepared',
             'errors': [],
             'name': 'obs_package',
@@ -322,6 +323,7 @@ class TestOBSImageBuildResult(object):
         mock_retire_job.assert_called_once_with()
         mock_unlock.assert_called_once_with()
         assert self.obs_result.image_status == {
+            'job_id': '815',
             'job_status': 'success',
             'errors': [],
             'name': 'obs_package',


### PR DESCRIPTION
Make sure the data contains a job_id attribute otherwise
it will not be picked up by the logger service