### PR TITLE
Fixup scope of logger service

### DIFF
--- a/mash/services/logger/service.py
+++ b/mash/services/logger/service.py
@@ -79,30 +79,21 @@ class LoggerService(BaseService):
 
         if 'job_id' in data:
             file_name = data.get('job_id')
-        else:
-            file_name = data.get('name', 'Mash')
+            log_file = self.config.get_log_file(file_name)
 
-        # Append log dir to file_name
-        log_file = self.config.get_log_file(file_name)
-
-        if os.path.exists(log_file):
-            mode = 'a'
-        else:
-            mode = 'w'
-
-        try:
-            with open(log_file, mode) as job_log:
-                job_log.write(
-                    ' '.join([
-                        data['levelname'],
-                        data['timestamp'],
-                        data['name'],
-                        os.linesep,
-                        data['msg'],
-                        os.linesep
-                    ])
+            try:
+                with open(log_file, 'a') as job_log:
+                    job_log.write(
+                        ' '.join([
+                            data['levelname'],
+                            data['timestamp'],
+                            data['name'],
+                            os.linesep,
+                            data['msg'],
+                            os.linesep
+                        ])
+                    )
+            except Exception as e:
+                raise MashLoggerException(
+                    'Could not write to log file: {0}'.format(e)
                 )
-        except Exception as e:
-            raise MashLoggerException(
-                'Could not write to log file: {0}'.format(e)
-            )

--- a/test/unit/services_logger_service_test.py
+++ b/test/unit/services_logger_service_test.py
@@ -80,24 +80,6 @@ class TestLoggerService(object):
             self.logger._process_log(self.channel, Mock(), Mock(), '')
 
     @patch('os.path.exists')
-    def test_logger_process_no_job_id(
-        self, mock_path_exists
-    ):
-        mock_path_exists.return_value = False
-        self.logger.config = self.config
-
-        with patch(open_name, create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.logger._process_log(
-                self.channel, Mock(), Mock(), json.dumps(self.message)
-            )
-            file_handle = mock_open.return_value.__enter__.return_value
-            file_handle.write.assert_called_with(
-                u'INFO 2017-11-01 11:36:36.782072 '
-                'LoggerService \n Test log message! \n'
-            )
-
-    @patch('os.path.exists')
     def test_logger_process_append(
         self, mock_path_exists
     ):
@@ -122,6 +104,7 @@ class TestLoggerService(object):
     ):
         mock_path_exists.return_value = True
         self.logger.config = self.config
+        self.message['job_id'] = '4711'
 
         with patch(open_name, create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)


### PR DESCRIPTION
the logger service should only log the job history from log
data providing a job_id. Any other log information which does
not have a job_id should be imho considered service specific
and covered by the service specific log file