### PR TITLE
Add timeboxed wait for obs results

### DIFF
--- a/mash/mash_exceptions.py
+++ b/mash/mash_exceptions.py
@@ -84,12 +84,6 @@ class MashOBSLookupException(MashException):
     """
 
 
-class MashOBSResultException(MashException):
-    """
-    Exception raised if the OBS result request failed
-    """
-
-
 class MashUploadException(MashException):
     """
     Exception raised if image upload to csp failed


### PR DESCRIPTION
If the obs service schedules an 'always' job, the job runs controlled by an interval scheduler which allows for one concurrent thread at a time. Once the job has been processed an api call in _wait_for_new_image similar to 'osc results --wait' blocks the thread until new results are available.

However the state that new results are available might never be reached due to external effects like a stale network or something else. In order to be not blocked forever and allow the scheduler to run
the job again _wait_for_new_image was refactored to run an extra subprocess to allow for process termination after a custom timeout.

The use of a subprocess is intentional because a thread can't be easily terminated and there is no code in the osc get_results api which allows a timeout