### PR TITLE
Refactor obs service thread usage

### DIFF
--- a/mash/services/obs_service.py
+++ b/mash/services/obs_service.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
-import time
 import logging
 import sys
 
@@ -28,17 +27,14 @@ def main(event_loop=True):
     """
     mash - obs service application entry point
     """
-    obs = None
     try:
         logging.basicConfig()
         log = logging.getLogger('mash')
         log.setLevel(logging.DEBUG)
         # run service, enter main loop
-        obs = OBSImageBuildResultService(
+        OBSImageBuildResultService(
             host='localhost', service_exchange='obs',
         )
-        while event_loop:
-            time.sleep(5)
     except MashException as e:
         # known exception
         log.error('%s: %s', type(e).__name__, format(e))
@@ -46,13 +42,10 @@ def main(event_loop=True):
     except KeyboardInterrupt:
         log.info('bye')
         sys.exit(0)
-    except SystemExit as e:
+    except SystemExit:
         # user exception, program aborted by user
-        sys.exit(e)
+        sys.exit(0)
     except Exception:
         # exception we did no expect, show python backtrace
         log.error('Unexpected error:')
         raise
-    finally:
-        if obs:
-            obs.close_connection()

--- a/test/unit/services_obs_test.py
+++ b/test/unit/services_obs_test.py
@@ -29,30 +29,27 @@ class TestOBS(object):
         mock_exit.assert_called_once_with(1)
 
     @patch('mash.services.obs_service.OBSImageBuildResultService')
-    @patch('time.sleep')
     @patch('sys.exit')
     def test_main_keyboard_interrupt(
-        self, mock_exit, mock_time, mock_OBSImageBuildResultService
+        self, mock_exit, mock_OBSImageBuildResultService
     ):
-        mock_time.side_effect = KeyboardInterrupt
+        mock_OBSImageBuildResultService.side_effect = KeyboardInterrupt
         main()
         mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.obs_service.OBSImageBuildResultService')
-    @patch('time.sleep')
     @patch('sys.exit')
     def test_main_system_exit(
-        self, mock_exit, mock_time, mock_OBSImageBuildResultService
+        self, mock_exit, mock_OBSImageBuildResultService
     ):
-        mock_time.side_effect = SystemExit()
+        mock_OBSImageBuildResultService.side_effect = SystemExit
         main()
-        mock_exit.assert_called_once_with(mock_time.side_effect)
+        mock_exit.assert_called_once_with(0)
 
     @patch('mash.services.obs_service.OBSImageBuildResultService')
-    @patch('time.sleep')
     def test_main_unexpected_error(
-        self, mock_time, mock_OBSImageBuildResultService
+        self, mock_OBSImageBuildResultService
     ):
-        mock_time.side_effect = Exception
+        mock_OBSImageBuildResultService.side_effect = Exception
         with raises(Exception):
             main()


### PR DESCRIPTION
sending messages to queues via pika in threads is not
safe. Thus the obs service has been refactored to use
callback methods and handlers. In addition the locking
code has been improved in a way that for lock and
unlock the current state of the metadata is checked
to avoid invalid request errors