### PR TITLE
Improve log messages send by obs service

### DIFF
--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -80,12 +80,7 @@ class OBSImageBuildResultService(BaseService):
                 self.channel.close()
 
     def _send_job_response(self, job_id, status_message):
-        result = {
-            'obs_job_log': {job_id: status_message}
-        }
-        self.log.info(
-            self._json_message(result), extra={'job_id': job_id}
-        )
+        self.log.info(status_message, extra={'job_id': job_id})
 
     def _send_listen_response(self, job_id, trigger_info):
         if job_id in self.clients:

--- a/test/unit/services_obs_service_test.py
+++ b/test/unit/services_obs_service_test.py
@@ -78,8 +78,7 @@ class TestOBSImageBuildResultService(object):
     def test_send_job_response(self):
         self.obs_result._send_job_response('815', {})
         self.obs_result.log.info.assert_called_once_with(
-            '{\n    "obs_job_log": {\n        "815": {}\n    }\n}',
-            extra={'job_id': '815'}
+            {}, extra={'job_id': '815'}
         )
 
     @patch.object(BaseService, 'bind_listener_queue')


### PR DESCRIPTION
This changes causes the sequence of log info to look like this

```
INFO  : 22:32:33 | 
INFO 2017-11-10 22:32:33,809 OBSImageBuildResultService
    Nonstop Job submitted

INFO  : 22:32:33 | 
INFO 2017-11-10 22:32:33,990 OBSImageBuildResultService
    Lock: Virtualization:Appliances:Images:Testing_x86/test-image-docker

INFO  : 22:32:34 | 
INFO 2017-11-10 22:32:34,398 OBSImageBuildResultService
    Job running

INFO  : 22:32:34 | 
INFO 2017-11-10 22:32:34,880 OBSImageBuildResultService
    Downloading image...

INFO  : 22:33:30 | 
INFO 2017-11-10 22:33:30,066 OBSImageBuildResultService
    Downloaded: ['/var/tmp/mash/images/Docker-openSUSE-Tumbleweed.x86_64-2.1.0-Build9.6.docker.tar.xz', '/var/tmp/mash/images/Docker-openSUSE-Tumbleweed.x86_64-2.1.0-Build9.6.docker.tar.xz.sha256']

INFO  : 22:33:30 | 
INFO 2017-11-10 22:33:30,067 OBSImageBuildResultService
    Job status: success

INFO  : 22:33:30 | 
INFO 2017-11-10 22:33:30,267 OBSImageBuildResultService
    Unlock: Virtualization:Appliances:Images:Testing_x86/test-image-docker

INFO  : 22:33:30 | 
INFO 2017-11-10 22:33:30,697 OBSImageBuildResultService
    Waiting for image update
```