### PR TITLE
Add iteration counter for obs log messages

### DIFF
--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -118,6 +118,7 @@ class OBSImageBuildResult(object):
         self.log_callback = None
         self.result_callback = None
         self.osc_process = None
+        self.iteration_count = 0
 
         self.image_status = self._init_status()
 
@@ -228,7 +229,11 @@ class OBSImageBuildResult(object):
 
     def _log_callback(self, message):
         if self.log_callback:
-            self.log_callback(self.job_id, message)
+            self.log_callback(
+                self.job_id, 'Pass[{0}]: {1}'.format(
+                    self.iteration_count, message
+                )
+            )
 
     def _result_callback(self):
         job_status = self.image_status['job_status']
@@ -403,6 +408,7 @@ class OBSImageBuildResult(object):
 
     def _update_image_status(self):
         try:
+            self.iteration_count += 1
             if self._lock() is False:
                 self.image_status['job_status'] = 'failed'
                 return

--- a/test/unit/services_obs_build_result_test.py
+++ b/test/unit/services_obs_build_result_test.py
@@ -74,9 +74,10 @@ class TestOBSImageBuildResult(object):
 
     def test_log_callback(self):
         self.obs_result.log_callback = Mock()
+        self.obs_result.iteration_count = 1
         self.obs_result._log_callback('message')
         self.obs_result.log_callback.assert_called_once_with(
-            '815', 'message'
+            '815', 'Pass[1]: message'
         )
 
     def test_result_callback(self):


### PR DESCRIPTION
This produces log messages with a Pass[X] prefix in front of a message send by instances of the OBSImageBuildResult class