### PR TITLE
Switch exchanges to direct type.

### DIFF
--- a/mash/log/handler.py
+++ b/mash/log/handler.py
@@ -29,7 +29,7 @@ class RabbitMQHandler(SocketHandler):
     def __init__(
         self, host='localhost', port=5672, exchange='logger',
         username='guest', password='guest',
-        routing_key='logger.{level}'
+        routing_key='mash.logger'
     ):
         """
         Initialize the handler instance.
@@ -58,7 +58,7 @@ class RabbitMQHandler(SocketHandler):
         """
         Format the log message to a json string.
         """
-        rabbit_attrs = ['msg', 'levelname', 'job_id']
+        rabbit_attrs = ['msg', 'job_id']
 
         data = {}
         record.msg = self.format(record)
@@ -107,7 +107,7 @@ class RabbitMQSocket(object):
     def declare_exchange(self):
         self.channel.exchange_declare(
             exchange=self.exchange,
-            exchange_type='topic',
+            exchange_type='direct',
             durable=True
         )
 
@@ -131,12 +131,10 @@ class RabbitMQSocket(object):
         """
         Override socket sendall method to publish message to exchange.
         """
-        level = json.loads(msg)['levelname']
-
         self.open()
         self.channel.basic_publish(
             exchange=self.exchange,
-            routing_key=self.routing_key.format(level=level),
+            routing_key=self.routing_key,
             body=msg,
             properties=pika.BasicProperties(
                 content_type='application/json',

--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -54,7 +54,7 @@ class BaseService(object):
         self.service_key = 'service_event'
 
         self._open_connection()
-        self._declare_topic_exchange(self.service_exchange)
+        self._declare_direct_exchange(self.service_exchange)
 
         logging.basicConfig()
         self.log = logging.getLogger(self.__class__.__name__)
@@ -163,7 +163,7 @@ class BaseService(object):
             self.connection.close()
 
     def _bind_queue(self, exchange, routing_key):
-        self._declare_topic_exchange(exchange)
+        self._declare_direct_exchange(exchange)
         declared_queue = self._declare_queue(
             '{0}.{1}'.format(exchange, routing_key)
         )
@@ -174,9 +174,9 @@ class BaseService(object):
         )
         return declared_queue.method.queue
 
-    def _declare_topic_exchange(self, exchange):
+    def _declare_direct_exchange(self, exchange):
         self.channel.exchange_declare(
-            exchange=exchange, exchange_type='topic', durable=True
+            exchange=exchange, exchange_type='direct', durable=True
         )
 
     def _declare_queue(self, queue):

--- a/mash/services/logger/service.py
+++ b/mash/services/logger/service.py
@@ -41,7 +41,7 @@ class LoggerService(BaseService):
 
         self.consume_queue(
             self._process_log, self._bind_logger_queue(
-                queue_name='mash.logger', route='mash.*'
+                queue_name='mash.logger', route='mash.logger'
             )
         )
         try:
@@ -55,7 +55,7 @@ class LoggerService(BaseService):
         Declare logger exchange and bind queue with routing
         key for logs.
         """
-        self._declare_topic_exchange(self.service_exchange)
+        self._declare_direct_exchange(self.service_exchange)
         self._declare_queue(queue_name)
         self.channel.queue_bind(
             exchange=self.service_exchange,
@@ -69,7 +69,7 @@ class LoggerService(BaseService):
         Callback for logger queue.
 
         1. Attempt to de-serialize the log message.
-        2. Determine log file name based on job_id or class name.
+        2. Determine log file name based on job_id.
         3. Write or append to log file.
         """
         channel.basic_ack(method.delivery_tag)

--- a/test/unit/log_handler_test.py
+++ b/test/unit/log_handler_test.py
@@ -55,7 +55,7 @@ class TestRabbitMQHandler(object):
             'user',
             'pass',
             'exchange',
-            'mash.{level}'
+            'mash.logger'
         )
 
         mock_pika_BlockingConnection.assert_called_once_with(None)
@@ -68,7 +68,7 @@ class TestRabbitMQHandler(object):
         self.connection.channel.assert_called_once_with()
         self.channel.exchange_declare.assert_called_once_with(
             exchange='exchange',
-            exchange_type='topic',
+            exchange_type='direct',
             durable=True
         )
 
@@ -80,7 +80,7 @@ class TestRabbitMQHandler(object):
 
         self.channel.basic_publish.assert_called_once_with(
             exchange='exchange',
-            routing_key='mash.INFO',
+            routing_key='mash.logger',
             body=msg,
             properties=props
         )

--- a/test/unit/services_base_service_test.py
+++ b/test/unit/services_base_service_test.py
@@ -75,7 +75,7 @@ class TestBaseService(object):
     def test_bind_service_queue(self):
         assert self.service.bind_service_queue() == 'queue'
         self.channel.exchange_declare.assert_called_once_with(
-            durable=True, exchange='obs', exchange_type='topic'
+            durable=True, exchange='obs', exchange_type='direct'
         )
         self.channel.queue_bind.assert_called_once_with(
             exchange='obs', queue='queue', routing_key='service_event'

--- a/test/unit/services_logger_service_test.py
+++ b/test/unit/services_logger_service_test.py
@@ -52,31 +52,31 @@ class TestLoggerService(object):
             mock_process_log, mock_bind_logger_queue.return_value
         )
         mock_bind_logger_queue.assert_called_once_with(
-            queue_name='mash.logger', route='mash.*'
+            queue_name='mash.logger', route='mash.logger'
         )
         self.logger.channel.start_consuming.side_effect = KeyboardInterrupt
         self.logger.post_init()
         self.logger.channel.stop_consuming.assert_called_once_with()
         self.logger.close_connection.assert_called_once_with()
 
-    @patch.object(LoggerService, '_declare_topic_exchange')
+    @patch.object(LoggerService, '_declare_direct_exchange')
     @patch.object(LoggerService, '_declare_queue')
     def test_logger_bind_logger_queue(
-        self, mock_declare_queue, mock_declare_topic_exchange
+        self, mock_declare_queue, mock_declare_direct_exchange
     ):
         self.logger.channel = Mock()
         self.logger.service_exchange = 'logger'
 
         assert self.logger._bind_logger_queue(
-            queue_name='mash.logger', route='mash.*'
+            queue_name='mash.logger', route='mash.logger'
         ) == 'mash.logger'
 
-        mock_declare_topic_exchange.assert_called_once_with('logger')
+        mock_declare_direct_exchange.assert_called_once_with('logger')
         mock_declare_queue.assert_called_once_with('mash.logger')
         self.logger.channel.queue_bind.assert_called_once_with(
             exchange='logger',
             queue='mash.logger',
-            routing_key='mash.*'
+            routing_key='mash.logger'
         )
 
     def test_logger_process_invalid_log(self):


### PR DESCRIPTION
Should not have the overhead of topic exchange with use of direct keys.

Note: The existing exchanges will need to be deleted in RabbitMQ instance to prevent exception in Pika when declaring.