### PR TITLE
Added mash credentials service

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -7,6 +7,7 @@
 
 setuptools
 PyYAML
+PyJWT
 APScheduler
 python-dateutil
 build-service-osc

--- a/config/mash_credentials.service
+++ b/config/mash_credentials.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Mash Credentials service
+After=syslog.target network.target
+Before=systemd-user-sessions.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/mash-credentials-service
+StandardOutput=null
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/credentials_job.py
+++ b/examples/credentials_job.py
@@ -1,0 +1,17 @@
+# example testing jobs and pipelining
+import pika
+
+connection = pika.BlockingConnection(
+    pika.ConnectionParameters(host='localhost')
+)
+channel = connection.channel()
+
+channel.queue_declare(queue='credentials.service_event', durable=True)
+
+channel.basic_publish(
+    exchange='credentials', routing_key='service_event', mandatory=True, body='{"credentials": {"csp": "ec2", "payload": {"ssh_key_pair_name": "xxx", "ssh_key_private_key_file": "xxx", "access_key": "xxx", "secret_key": "xxx"}}}'
+)
+
+if channel.is_open:
+    channel.close()
+connection.close()

--- a/examples/credentials_read.py
+++ b/examples/credentials_read.py
@@ -1,0 +1,28 @@
+import pika
+import sys
+
+connection = pika.BlockingConnection(
+    pika.ConnectionParameters(host='localhost')
+)
+channel = connection.channel()
+
+listen_to_queue = 'credentials.ec2'
+channel.queue_declare(queue=listen_to_queue, durable=True)
+
+print('waiting for credentials service...')
+
+def callback(channel, method, properties, body):
+    channel.basic_ack(method.delivery_tag)
+    print(body)
+    connection.close()
+    sys.exit(0)
+
+try:
+    channel.basic_consume(
+        callback, queue=listen_to_queue
+    )
+    channel.start_consuming()
+except KeyboardInterrupt:
+    if channel.is_open:
+        channel.close()
+    connection.close()

--- a/mash/services/credentials/amazon.py
+++ b/mash/services/credentials/amazon.py
@@ -33,10 +33,3 @@ class CredentialsAmazon(CredentialsBase):
             'access_key': None,
             'secret_key': None
         }
-
-    def set_credentials(self, secret_token):
-        self.secret_token = secret_token
-
-    def get_credentials(self):
-        # TODO: fill in secret information from token
-        return self.credentials

--- a/mash/services/credentials/base.py
+++ b/mash/services/credentials/base.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
-# project
+import jwt
 
 
 class CredentialsBase(object):
@@ -27,10 +27,12 @@ class CredentialsBase(object):
         self.post_init()
 
     def post_init(self):
-        pass
+        self.credentials = {}
 
     def set_credentials(self, secret_token):
-        raise NotImplementedError
+        self.credentials.update(
+            jwt.decode(secret_token, 'secret', algorithms=['HS256'])
+        )
 
     def get_credentials(self):
-        raise NotImplementedError
+        return self.credentials

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2017 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+import jwt
+
+# project
+from mash.services.base_service import BaseService
+from mash.utils.json_format import JsonFormat
+
+
+class CredentialsService(BaseService):
+    """
+    Implements CredentialsService based on web token technology
+
+    Note:
+    The current implementation is not final ! The service acts as
+    a stub service in order to develop other mash services which
+    requires cloud credentials. Thus error handling, security aspects
+    and token workflow as well as request validation are not
+    completed and will change for the final version of this service
+    """
+    def post_init(self):
+        # consume on service queue
+        self.consume_queue(
+            self._control_in, self.bind_service_queue()
+        )
+        try:
+            self.channel.start_consuming()
+        except KeyboardInterrupt:
+            self.channel.stop_consuming()
+            self.close_connection()
+
+    def _send_control_response(self, result):
+        message = result['message']
+        if result['ok']:
+            self.log.info(message)
+        else:
+            self.log.error(message)
+
+    def _control_in(self, channel, method, properties, message):
+        """
+        On message sent by client
+
+        The message is interpreted as json data and allows for:
+
+        1. add new credentials payload
+        """
+        channel.basic_ack(method.delivery_tag)
+        message_data = {}
+        try:
+            message_data = JsonFormat.json_loads_byteified(format(message))
+        except Exception as e:
+            return self._send_control_response(
+                {
+                    'ok': False,
+                    'message': 'JSON:deserialize error: {0} : {1}'.format(
+                        message, e
+                    )
+                }
+            )
+        if 'credentials' in message_data:
+            result = self._create_credentials(message_data)
+        else:
+            result = {
+                'ok': False,
+                'message': 'No idea what to do with: {0}'.format(message_data)
+            }
+        self._send_control_response(result)
+
+    def _create_credentials(self, data):
+        """
+        Create JWT token from the provided information and send
+        it to the authentication exchange
+
+        credentials description example:
+        {
+          "credentials": {
+              "csp": "ec2",
+              "payload": {
+                  ...credentials data
+              }
+          }
+        }
+        """
+        payload = None
+        csp = None
+        if 'credentials' in data:
+            job = data['credentials']
+            if 'payload' in job:
+                payload = data['credentials']['payload']
+            if 'csp' in job:
+                csp = data['credentials']['csp']
+
+        if payload and csp:
+            token = jwt.encode(
+                payload, 'secret', algorithm='HS256'
+            )
+            self._bind_queue(self.service_exchange, csp)
+            self._publish(
+                self.service_exchange, csp, JsonFormat.json_message(
+                    {'credentials': token}
+                )
+            )
+            result = {
+                'ok': True,
+                'message': 'Credentials token created'
+            }
+        else:
+            result = {
+                'ok': False,
+                'message': 'Insufficient job information'
+            }
+        return result

--- a/mash/services/credentials_service.py
+++ b/mash/services/credentials_service.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2017 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+import logging
+import sys
+
+# project
+from mash.mash_exceptions import MashException
+from mash.services.credentials.service import CredentialsService
+
+
+def main(event_loop=True):
+    """
+    mash - credentials service application entry point
+    """
+    try:
+        logging.basicConfig()
+        log = logging.getLogger('MashService')
+        log.setLevel(logging.DEBUG)
+        # run service, enter main loop
+        CredentialsService(
+            host='localhost', service_exchange='credentials',
+        )
+    except MashException as e:
+        # known exception
+        log.error('{0}: {1}'.format(type(e).__name__, format(e)))
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(0)
+    except SystemExit:
+        # user exception, program aborted by user
+        sys.exit(0)
+    except Exception:
+        # exception we did no expect, show python backtrace
+        log.error('Unexpected error:')
+        raise

--- a/package/mash-spec-template
+++ b/package/mash-spec-template
@@ -30,6 +30,7 @@ BuildRequires:  python-setuptools
 Requires:       osc
 Requires:       rabbitmq-server
 Requires:       python-PyYAML
+Requires:       python-PyJWT
 Requires:       python-pika
 Requires:       python-APScheduler >= 3.3.1
 Requires:       python-python-dateutil
@@ -61,6 +62,9 @@ install -D -m 644 config/mash_logger.service \
 install -D -m 644 config/logger_config.yml \
     %{buildroot}%{_sysconfdir}/%{name}/logger_config.yml
 
+install -D -m 644 config/mash_credentials.service \
+    %{buildroot}%{_unitdir}/mash_credentials.service
+
 %files
 %defattr(-,root,root,-)
 %{python_sitelib}/*
@@ -72,5 +76,8 @@ install -D -m 644 config/logger_config.yml \
 %{_bindir}/mash-logger-service
 %{_unitdir}/mash_logger.service
 %config(noreplace) %{_sysconfdir}/%{name}/logger_config.yml
+
+%{_bindir}/mash-credentials-service
+%{_unitdir}/mash_credentials.service
 
 %changelog

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ config = {
     'install_requires': [
         'setuptools>=5.4',
         'PyYAML',
+        'PyJWT',
         'python-dateutil',
         'APScheduler>=3.3.1',
         'pika'
@@ -29,7 +30,8 @@ config = {
     'entry_points': {
         'console_scripts': [
             'mash-obs-service=mash.services.obs_service:main',
-            'mash-logger-service=mash.services.logger_service:main'
+            'mash-logger-service=mash.services.logger_service:main',
+            'mash-credentials-service=mash.services.credentials_service:main'
         ]
     },
     'include_package_data': True,

--- a/test/unit/services_credentials_amazon_test.py
+++ b/test/unit/services_credentials_amazon_test.py
@@ -5,11 +5,7 @@ class TestCredentialsAmazon(object):
     def setup(self):
         self.credentials = CredentialsAmazon()
 
-    def test_set_credentials(self):
-        self.credentials.set_credentials('token')
-        assert self.credentials.secret_token == 'token'
-
-    def test_get_credentials(self):
+    def test_post_init(self):
         assert self.credentials.get_credentials() == {
             'access_key': None,
             'secret_key': None,

--- a/test/unit/services_credentials_base_test.py
+++ b/test/unit/services_credentials_base_test.py
@@ -1,6 +1,6 @@
-from pytest import raises
-
 from mash.services.credentials.base import CredentialsBase
+
+import jwt
 
 
 class TestCredentialsBase(object):
@@ -8,9 +8,11 @@ class TestCredentialsBase(object):
         self.credentials = CredentialsBase()
 
     def test_set_credentials(self):
-        with raises(NotImplementedError):
-            self.credentials.set_credentials('token')
+        token = jwt.encode(
+            {'some': 'payload'}, 'secret', algorithm='HS256'
+        )
+        self.credentials.set_credentials(token)
+        assert self.credentials.credentials['some'] == 'payload'
 
     def test_get_credentials(self):
-        with raises(NotImplementedError):
-            self.credentials.get_credentials()
+        assert self.credentials.get_credentials() == {}

--- a/test/unit/services_credentials_factory_test.py
+++ b/test/unit/services_credentials_factory_test.py
@@ -1,0 +1,14 @@
+from pytest import raises
+from mock import patch
+
+from mash.services.credentials import Credentials
+from mash.mash_exceptions import MashCredentialsException
+
+
+class TestCredentials(object):
+    @patch('mash.services.credentials.CredentialsAmazon')
+    def test_credentials_amazon(self, mock_CredentialsAmazon):
+        Credentials('ec2')
+        mock_CredentialsAmazon.assert_called_once_with(None)
+        with raises(MashCredentialsException):
+            Credentials('foo')

--- a/test/unit/services_credentials_service_test.py
+++ b/test/unit/services_credentials_service_test.py
@@ -1,0 +1,109 @@
+from mock import patch
+from mock import Mock
+
+from mash.services.base_service import BaseService
+from mash.services.credentials.service import CredentialsService
+
+
+class TestCredentialsService(object):
+    @patch.object(BaseService, '__init__')
+    def setup(self, mock_BaseService):
+        mock_BaseService.return_value = None
+        self.service = CredentialsService()
+        self.service.service_exchange = 'credentials'
+        self.service.channel = Mock()
+        self.service.close_connection = Mock()
+        self.service.consume_queue = Mock()
+        self.service.bind_service_queue = Mock()
+        self.service._bind_queue = Mock()
+        self.service._publish = Mock()
+        self.service.log = Mock()
+
+    @patch.object(CredentialsService, '_control_in')
+    def test_post_init(self, mock_control_in):
+        self.service.post_init()
+        self.service.consume_queue.assert_called_once_with(
+            mock_control_in, self.service.bind_service_queue.return_value
+        )
+        self.service.channel.start_consuming.assert_called_once_with()
+        self.service.channel.start_consuming.side_effect = KeyboardInterrupt
+        self.service.post_init()
+        self.service.channel.stop_consuming.assert_called_once_with()
+        self.service.close_connection.assert_called_once_with()
+
+    def test_send_control_response(self):
+        result = {
+            'message': 'message',
+            'ok': False
+        }
+        self.service._send_control_response(result)
+        self.service.log.error.assert_called_once_with('message')
+        result['ok'] = True
+        self.service._send_control_response(result)
+        self.service.log.info.assert_called_once_with('message')
+
+    @patch.object(CredentialsService, '_create_credentials')
+    @patch.object(CredentialsService, '_send_control_response')
+    def test_control_in(
+        self, mock_send_control_response, mock_create_credentials
+    ):
+        message = '{"credentials": {"csp": "ec2", "payload": {"foo": "bar"}}}'
+        channel = Mock()
+        method = Mock()
+        self.service._control_in(channel, method, Mock(), message)
+        channel.basic_ack.assert_called_once_with(method.delivery_tag)
+        mock_create_credentials.assert_called_once_with(
+            {
+                'credentials': {
+                    'payload': {'foo': 'bar'},
+                    'csp': 'ec2'
+                }
+            }
+        )
+        mock_send_control_response.assert_called_once_with(
+            mock_create_credentials.return_value
+        )
+        mock_send_control_response.reset_mock()
+        message = 'foo'
+        self.service._control_in(channel, method, Mock(), message)
+        mock_send_control_response.assert_called_once_with(
+            {
+                'message':
+                    'JSON:deserialize error: foo : ' +
+                    'No JSON object could be decoded',
+                'ok': False
+            }
+        )
+        mock_send_control_response.reset_mock()
+        message = '{"foo": "bar"}'
+        self.service._control_in(channel, method, Mock(), message)
+        mock_send_control_response.assert_called_once_with(
+            {
+                'message': "No idea what to do with: {'foo': 'bar'}",
+                'ok': False
+            }
+        )
+
+    def test_create_credentials(self):
+        data = {
+            'credentials': {
+                'csp': 'ec2',
+                'payload': {'foo': 'bar'}
+            }
+        }
+        assert self.service._create_credentials(data) == {
+            'ok': True,
+            'message': 'Credentials token created'
+        }
+        self.service._bind_queue.assert_called_once_with(
+            'credentials', 'ec2'
+        )
+        self.service._publish.assert_called_once_with(
+            'credentials', 'ec2', '{\n    "credentials": ' +
+            '"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIif' +
+            'Q.dtxWM6MIcgoeMgH87tGvsNDY6cHWL6MGW4LeYvnm1JA"\n}'
+        )
+        assert self.service._create_credentials({}) == {
+            'ok': False,
+            'message': 'Insufficient job information'
+        }

--- a/test/unit/services_credentials_test.py
+++ b/test/unit/services_credentials_test.py
@@ -1,14 +1,49 @@
 from pytest import raises
 from mock import patch
 
-from mash.services.credentials import Credentials
-from mash.mash_exceptions import MashCredentialsException
+from mash.mash_exceptions import MashException
+from mash.services.credentials_service import main
 
 
 class TestCredentials(object):
-    @patch('mash.services.credentials.CredentialsAmazon')
-    def test_credentials_amazon(self, mock_CredentialsAmazon):
-        Credentials('ec2')
-        mock_CredentialsAmazon.assert_called_once_with(None)
-        with raises(MashCredentialsException):
-            Credentials('foo')
+    @patch('mash.services.credentials_service.CredentialsService')
+    def test_main(self, mock_CredentialsService):
+        main(event_loop=False)
+        mock_CredentialsService.assert_called_once_with(
+            host='localhost', service_exchange='credentials'
+        )
+
+    @patch('mash.services.credentials_service.CredentialsService')
+    @patch('sys.exit')
+    def test_main_mash_error(
+        self, mock_exit, mock_CredentialsService
+    ):
+        mock_CredentialsService.side_effect = MashException('error')
+        main(event_loop=False)
+        mock_exit.assert_called_once_with(1)
+
+    @patch('mash.services.credentials_service.CredentialsService')
+    @patch('sys.exit')
+    def test_main_keyboard_interrupt(
+        self, mock_exit, mock_CredentialsService
+    ):
+        mock_CredentialsService.side_effect = KeyboardInterrupt
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.credentials_service.CredentialsService')
+    @patch('sys.exit')
+    def test_main_system_exit(
+        self, mock_exit, mock_CredentialsService
+    ):
+        mock_CredentialsService.side_effect = SystemExit
+        main()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mash.services.credentials_service.CredentialsService')
+    def test_main_unexpected_error(
+        self, mock_CredentialsService
+    ):
+        mock_CredentialsService.side_effect = Exception
+        with raises(Exception):
+            main()


### PR DESCRIPTION
Note:  The current implementation is not final !

The service acts as a stub service in order to develop other mash services which requires cloud credentials. Thus error handling, security aspects and token workflow as well as request validation
are not completed and will change for the final version of this service