### PR TITLE
Reference ec2uploadimg now from pypi

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -12,3 +12,4 @@ APScheduler
 python-dateutil
 build-service-osc
 pika
+ec2uploadimg

--- a/mash/services/uploader/cloud/amazon.py
+++ b/mash/services/uploader/cloud/amazon.py
@@ -15,12 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+from ec2utils.ec2uploadimg import EC2ImageUploader
+
 # project
 from mash.services.uploader.cloud.base import UploadBase
 from mash.mash_exceptions import MashUploadException
-
-# TODO: ec2uploadimg is not on pypi
-# from ec2utils.ec2uploadimg import EC2ImageUploader
 
 
 class UploadAmazon(UploadBase):

--- a/package/mash-spec-template
+++ b/package/mash-spec-template
@@ -34,6 +34,7 @@ Requires:       python-PyJWT
 Requires:       python-pika
 Requires:       python-APScheduler >= 3.3.1
 Requires:       python-python-dateutil
+Requires:       python-ec2uploadimg
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
In preperation to really use ec2uploadimg in development
environments and when installing the mash package this
patch now activates to fetch Roberts modules