### PR TITLE
Fixed tests and dict order raise condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: check test
 test:
 	cd test/unit && \
 	py.test --no-cov-on-fail --cov=mash \
-		--cov-report=term-missing --cov-fail-under=90 --cov-config .coveragerc
+		--cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
 
 check:
 	flake8 --statistics -j auto --count mash

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -149,7 +149,7 @@ class TestingService(BaseService):
             }
         }
 
-        return json.dumps(data)
+        return json.dumps(data, sort_keys=True)
 
     def _handle_jobs(self, message):
         """

--- a/test/unit/services/jobcreator/jobcreator_service_test.py
+++ b/test/unit/services/jobcreator/jobcreator_service_test.py
@@ -71,8 +71,9 @@ class TestJobCreatorService(object):
         mock_bind_queue, mock_jobcreator_config, mock_start, mock_stop
     ):
         mock_jobcreator_config.return_value = self.config
-        self.config.get_log_file.return_value = \
-            '/var/log/mash/job_creator_service.log'
+        self.config.get_log_file.return_value = MagicMock(
+            return_value='/var/log/mash/job_creator_service.log'
+        )
 
         mock_start.side_effect = KeyboardInterrupt()
 

--- a/test/unit/services/testing/testing_service_test.py
+++ b/test/unit/services/testing/testing_service_test.py
@@ -35,9 +35,9 @@ class TestIPATestingService(object):
         self.testing.service_exchange = 'testing'
 
         self.error_message = '{"testing_result": ' \
-            '{"job_id": "1", "status": 1, "image_id": "image123"}}'
+            '{"image_id": "image123", "job_id": "1", "status": 1}}'
         self.status_message = '{"testing_result": ' \
-            '{"job_id": "1", "status": 0, "image_id": "image123"}}'
+            '{"image_id": "image123", "job_id": "1", "status": 0}}'
 
     @patch.object(TestingService, 'set_logfile')
     @patch.object(TestingService, 'stop')
@@ -79,8 +79,9 @@ class TestIPATestingService(object):
         mock_bind_service_queue, mock_testing_config, mock_start, mock_stop
     ):
         mock_testing_config.return_value = self.config
-        self.config.get_log_file.return_value = \
-            '/var/log/mash/testing_service.log'
+        self.config.get_log_file.return_value = MagicMock(
+            return_value='/var/log/mash/testing_service.log'
+        )
 
         mock_start.side_effect = KeyboardInterrupt()
 


### PR DESCRIPTION
Fixed unit test expecting /var/log/mash/job_creator_service.log to
be really present on the system
Fixed message check which is formed from a dictionary but the
order of the dict traversal is not unique