### PR TITLE
Revert magicmock.

### DIFF
--- a/test/unit/services/jobcreator/jobcreator_service_test.py
+++ b/test/unit/services/jobcreator/jobcreator_service_test.py
@@ -60,6 +60,7 @@ class TestJobCreatorService(object):
         mock_start.assert_called_once_with()
         mock_stop.assert_called_once_with()
 
+    @patch.object(JobCreatorService, 'set_logfile')
     @patch.object(JobCreatorService, 'stop')
     @patch.object(JobCreatorService, 'start')
     @patch('mash.services.jobcreator.service.JobCreatorConfig')
@@ -68,7 +69,8 @@ class TestJobCreatorService(object):
     @patch.object(JobCreatorService, 'consume_queue')
     def test_job_creator_post_init_exceptions(
         self, mock_consume_queue, mock_process_message,
-        mock_bind_queue, mock_jobcreator_config, mock_start, mock_stop
+        mock_bind_queue, mock_jobcreator_config, mock_start, mock_stop,
+        mock_set_logfile
     ):
         mock_jobcreator_config.return_value = self.config
         self.config.get_log_file.return_value = \

--- a/test/unit/services/testing/testing_service_test.py
+++ b/test/unit/services/testing/testing_service_test.py
@@ -68,6 +68,7 @@ class TestIPATestingService(object):
         mock_start.assert_called_once_with()
         mock_stop.assert_called_once_with()
 
+    @patch.object(TestingService, 'set_logfile')
     @patch.object(TestingService, 'stop')
     @patch.object(TestingService, 'start')
     @patch('mash.services.testing.service.TestingConfig')
@@ -76,7 +77,8 @@ class TestIPATestingService(object):
     @patch.object(TestingService, 'consume_queue')
     def test_testing_post_init_exceptions(
         self, mock_consume_queue, mock_handle_jobs,
-        mock_bind_service_queue, mock_testing_config, mock_start, mock_stop
+        mock_bind_service_queue, mock_testing_config, mock_start, mock_stop,
+        mock_set_logfile
     ):
         mock_testing_config.return_value = self.config
         self.config.get_log_file.return_value = \


### PR DESCRIPTION
- get_log_file should return a string not an object.
- Mock the base set_logfile method
  - Test should pass without requiring log files on test system.