### PR TITLE
Cleanup logger service tests.

### DIFF
--- a/mash/log/handler.py
+++ b/mash/log/handler.py
@@ -68,7 +68,7 @@ class RabbitMQHandler(SocketHandler):
             if hasattr(record, attr):
                 data[attr] = getattr(record, attr)
 
-        return json.dumps(data)
+        return json.dumps(data, sort_keys=True)
 
 
 class RabbitMQSocket(object):

--- a/test/unit/log_handler_test.py
+++ b/test/unit/log_handler_test.py
@@ -9,39 +9,59 @@ from mash.log.handler import (
 
 
 class TestRabbitMQHandler(object):
-    @patch('mash.log.handler.Connection')
-    def setup(self, mock_connection):
+    def setup(self):
         self.connection = Mock()
         self.channel = Mock()
         self.channel.exchange.declare.return_value = None
         self.channel.basic.publish.return_value = None
         self.connection.channel.return_value = self.channel
 
-        mock_connection.return_value = self.connection
         self.handler = RabbitMQHandler()
 
-    def test_rabbit_handler_messages(self):
+    @patch('mash.log.handler.Connection')
+    def test_rabbit_handler_messages(self, mock_connection):
+        mock_connection.return_value = self.connection
+
         log = logging.getLogger('log_handler_test')
         log.addHandler(self.handler)
         log.setLevel(logging.DEBUG)
+
         log.info('Test %s', 'args')
+        self.channel.basic.publish.assert_called_once_with(
+            exchange='logger',
+            routing_key='mash.logger',
+            body='{"msg": "Test args"}',
+            properties={
+                'content_type': 'application/json',
+                'delivery_mode': 2
+            }
+        )
+        self.channel.basic.publish.reset_mock()
+
         log.info('Job finished!', extra={'job_id': '4711'})
+        self.channel.basic.publish.assert_called_once_with(
+            exchange='logger',
+            routing_key='mash.logger',
+            body='{"job_id": "4711", "msg": "Job finished!"}',
+            properties={
+                'content_type': 'application/json',
+                'delivery_mode': 2
+            }
+        )
+        self.channel.basic.publish.reset_mock()
 
         try:
             raise Exception('Broken')
         except Exception:
             log.exception('Test exc_info')
 
+        assert self.channel.basic.publish.call_count == 1
+
     @patch('mash.log.handler.Connection')
     def test_rabbit_socket(self, mock_connection):
-        self.connection = Mock()
-        self.channel = Mock()
-        self.channel.exchange.declare.return_value = None
-        self.channel.basic.publish.return_value = None
-        self.connection.channel.return_value = self.channel
+        mock_connection.return_value = self.connection
         self.connection.close.return_value = None
 
-        mock_connection.return_value = self.connection
         socket = RabbitMQSocket(
             'host',
             1234,


### PR DESCRIPTION
- Tests were sending messages to queue if Rabbit instance was running.
- Move mocked connection to the test itself where connection is called.
- Assert messages published through channel.