### PR TITLE
Merge master testing service and job config store.

### DIFF
--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -23,9 +23,5 @@ class Defaults(object):
     """
 
     @classmethod
-    def get_config(self):
-        return '/etc/mash/uploader_config.yml'
-
-    @classmethod
-    def get_log_file(self):
-        return '/tmp/uploader_service.log'
+    def get_job_directory(self, service_name):
+        return '/var/lib/mash/{0}_jobs/'.format(service_name)

--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -15,13 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
+
+import json
 import logging
+import os
 
 from amqpstorm import Connection
 
 # project
 from mash.log.filter import BaseServiceFilter
 from mash.log.handler import RabbitMQHandler
+from mash.services.base_defaults import Defaults
 from mash.mash_exceptions import (
     MashRabbitConnectionException,
     MashLogSetupException
@@ -53,6 +57,12 @@ class BaseService(object):
         self.service_exchange = service_exchange
         self.service_queue = 'service'
         self.job_document_key = 'job_document'
+
+        # setup service data directory
+        self.job_directory = os.makedirs(
+            Defaults.get_job_directory(self.service_exchange),
+            exist_ok=True
+        )
 
         self._open_connection()
         self._bind_queue(
@@ -186,3 +196,26 @@ class BaseService(object):
 
     def _declare_queue(self, queue):
         return self.channel.queue.declare(queue=queue, durable=True)
+
+    def persist_job_config(self, config):
+        config['job_file'] = '{0}job-{1}.json'.format(
+            self.job_directory, config['id']
+        )
+
+        with open(config['job_file'], 'w') as config_file:
+            config_file.write(json.dumps(config, sort_keys=True))
+
+        return config['job_file']
+
+    def restart_jobs(self, callback):
+        """
+        Restart jobs from config files.
+
+        Recover from service failure with existing jobs.
+        """
+        for job_file in os.listdir(self.job_directory):
+            with open(os.path.join(self.job_directory, job_file), 'r') \
+                    as conf_file:
+                job_config = json.load(conf_file)
+
+            callback(job_config)

--- a/mash/services/obs/defaults.py
+++ b/mash/services/obs/defaults.py
@@ -15,18 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
-import distutils
 
 
 class Defaults(object):
     """
     Default values
     """
-    @classmethod
-    def get_jobs_dir(self):
-        jobs_dir = '/var/tmp/mash/obs_jobs/'
-        distutils.dir_util.mkpath(jobs_dir)
-        return jobs_dir
 
     @classmethod
     def get_config(self):

--- a/mash/services/testing/config.py
+++ b/mash/services/testing/config.py
@@ -35,22 +35,6 @@ class TestingConfig(BaseConfig):
     def __init__(self, config_file=Defaults.get_config()):
         super(TestingConfig, self).__init__(config_file)
 
-    def get_jobs_dir(self):
-        """
-        Return job config backup dir:
-
-        testing:
-          jobs_dir: /var/lib/mash/testing_jobs/
-
-        If no configuration exists the jobs dir from the
-        Defaults class is returned.
-        :rtype: string
-        """
-        jobs_dir = self._get_attribute(
-            element='testing', attribute='jobs_dir'
-        )
-        return jobs_dir if jobs_dir else Defaults.get_jobs_dir()
-
     def get_log_file(self):
         """
         Return log file name:

--- a/mash/services/testing/defaults.py
+++ b/mash/services/testing/defaults.py
@@ -16,8 +16,6 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-import os
-
 
 class Defaults(object):
     """
@@ -27,12 +25,6 @@ class Defaults(object):
     @classmethod
     def get_config(self):
         return '/etc/mash/testing_config.yml'
-
-    @classmethod
-    def get_jobs_dir(self):
-        jobs_dir = '/var/lib/mash/testing_jobs/'
-        os.makedirs(jobs_dir, exist_ok=True)
-        return jobs_dir
 
     @classmethod
     def get_log_file(self):

--- a/test/unit/services/testing/testing_config_test.py
+++ b/test/unit/services/testing/testing_config_test.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from mash.services.testing.config import TestingConfig
 
 
@@ -13,12 +11,3 @@ class TestTestingConfig(object):
     def test_get_log_file(self):
         assert self.empty_config.get_log_file() == \
             '/var/log/mash/testing_service.log'
-
-    @patch('mash.services.testing.defaults.os.makedirs')
-    def test_get_jobs_dir(self, mock_makedirs):
-        assert self.empty_config.get_jobs_dir() == \
-            '/var/lib/mash/testing_jobs/'
-        mock_makedirs.assert_called_once_with(
-            '/var/lib/mash/testing_jobs/',
-            exist_ok=True
-        )

--- a/test/unit/services/testing/testing_service_test.py
+++ b/test/unit/services/testing/testing_service_test.py
@@ -1,5 +1,3 @@
-import io
-
 from pytest import raises
 from unittest.mock import call, MagicMock, Mock, patch
 
@@ -48,7 +46,7 @@ class TestIPATestingService(object):
     @patch.object(TestingService, 'set_logfile')
     @patch.object(TestingService, 'stop')
     @patch.object(TestingService, 'start')
-    @patch.object(TestingService, '_restart_jobs')
+    @patch.object(TestingService, 'restart_jobs')
     @patch('mash.services.testing.service.TestingConfig')
     @patch.object(TestingService, '_process_message')
     @patch.object(TestingService, 'consume_queue')
@@ -76,7 +74,7 @@ class TestIPATestingService(object):
     @patch.object(TestingService, 'set_logfile')
     @patch.object(TestingService, 'stop')
     @patch.object(TestingService, 'start')
-    @patch.object(TestingService, '_restart_jobs')
+    @patch.object(TestingService, 'restart_jobs')
     @patch('mash.services.testing.service.TestingConfig')
     @patch.object(TestingService, '_handle_jobs')
     @patch.object(TestingService, 'consume_queue')
@@ -102,7 +100,7 @@ class TestIPATestingService(object):
         mock_stop.assert_called_once_with()
 
     @patch.object(TestingService, '_validate_job')
-    @patch.object(TestingService, '_persist_job_config')
+    @patch.object(TestingService, 'persist_job_config')
     @patch.object(TestingService, '_process_message')
     @patch.object(TestingService, '_bind_queue')
     def test_testing_add_job(
@@ -114,14 +112,14 @@ class TestIPATestingService(object):
         job._get_metadata.return_value = {'job_id': '1'}
 
         mock_validate_job.return_value = job
-        mock_persist_config.return_value = 'config_file.json'
+        mock_persist_config.return_value = 'job_file.json'
 
         self.testing._add_job({'id': '1'})
 
         # Dict is mutable, mock compares the final value of Dict
         # not the initial value that was passed in.
         mock_validate_job.assert_called_once_with(
-            {'id': '1', 'config_file': 'config_file.json'}
+            {'id': '1', 'job_file': 'job_file.json'}
         )
         self.testing.log.info.assert_called_once_with(
             'Job queued, awaiting uploader result.',
@@ -282,24 +280,6 @@ class TestIPATestingService(object):
             'Message not received: {0}'.format('invalid')
         )
 
-    @patch('mash.services.testing.service.NamedTemporaryFile')
-    def test_testing_persist_job_config(self, mock_temp_file):
-        self.testing.jobs_dir = 'tmp-dir'
-
-        tmp_file = Mock()
-        tmp_file.name = 'tmp-dir/job-test.json'
-        mock_temp_file.return_value = tmp_file
-
-        with patch(open_name, create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.testing._persist_job_config({'id': '1'})
-            file_handle = mock_open.return_value.__enter__.return_value
-            # Dict is mutable, mock compares the final value of Dict
-            # not the initial value that was passed in.
-            file_handle.write.assert_called_with(
-                u'{"config_file": "tmp-dir/job-test.json", "id": "1"}'
-            )
-
     @patch.object(TestingService, '_test_image')
     def test_testing_process_message_listener_event(self, mock_test_image):
         self.method['routing_key'] = 'listener_1'
@@ -438,25 +418,6 @@ class TestIPATestingService(object):
             'Message not received: {0}'.format(self.error_message),
             extra={'job_id': '1'}
         )
-
-    @patch.object(TestingService, '_add_job')
-    @patch('mash.services.testing.service.json.load')
-    @patch('mash.services.testing.service.os.listdir')
-    def test_testing_restart_jobs(
-        self, mock_os_listdir, mock_json_load, mock_add_job
-    ):
-        self.testing.jobs_dir = 'tmp-dir'
-        mock_os_listdir.return_value = ['job-123.json']
-        mock_json_load.return_value = {'id': '1'}
-
-        with patch(open_name, create=True) as mock_open:
-            mock_open.return_value = MagicMock(spec=io.IOBase)
-            self.testing._restart_jobs()
-
-            file_handle = mock_open.return_value.__enter__.return_value
-            file_handle.read.call_count == 1
-
-        mock_add_job.assert_called_once_with({'id': '1'})
 
     def test_testing_run_test(self):
         job = Mock()

--- a/test/unit/services_base_defaults_test.py
+++ b/test/unit/services_base_defaults_test.py
@@ -1,0 +1,6 @@
+from mash.services.base_defaults import Defaults
+
+
+def test_get_job_directory():
+    job_directory = Defaults.get_job_directory('testing')
+    assert job_directory == '/var/lib/mash/testing_jobs/'

--- a/test/unit/services_uploader_service_test.py
+++ b/test/unit/services_uploader_service_test.py
@@ -4,8 +4,7 @@ from unittest.mock import call
 from unittest.mock import Mock
 
 from .test_helper import (
-    patch_open,
-    context_manager
+    patch_open
 )
 
 from mash.services.uploader.service import UploadImageService
@@ -15,19 +14,17 @@ from mash.services.base_service import BaseService
 class TestUploadImageService(object):
     @patch('mash.services.uploader.service.UploaderConfig')
     @patch('mash.services.base_service.BaseService.set_logfile')
-    @patch('mash.services.uploader.service.mkpath')
     @patch('mash.services.uploader.service.BackgroundScheduler')
-    @patch.object(UploadImageService, '_schedule_job')
     @patch.object(UploadImageService, '_process_message')
+    @patch.object(UploadImageService, 'restart_jobs')
     @patch.object(BaseService, '__init__')
     @patch('os.listdir')
     @patch('logging.getLogger')
     @patch('atexit.register')
     def setup(
         self, mock_register, mock_log, mock_listdir,
-        mock_BaseService, mock_process_message, mock_schedule_job,
-        mock_BackgroundScheduler,
-        mock_mkpath, mock_set_logfile,
+        mock_BaseService, mock_restart_jobs, mock_process_message,
+        mock_BackgroundScheduler, mock_set_logfile,
         mock_UploaderConfig
     ):
         scheduler = Mock()
@@ -55,14 +52,9 @@ class TestUploadImageService(object):
 
         mock_set_logfile.assert_called_once_with('logfile')
 
-        mock_mkpath.assert_called_once_with('/var/tmp/mash/uploader_jobs/')
-
         mock_BackgroundScheduler.assert_called_once_with(timezone=utc)
         scheduler.start.assert_called_once_with()
-
-        mock_schedule_job.assert_called_once_with(
-            '/var/tmp/mash/uploader_jobs//job'
-        )
+        mock_restart_jobs.assert_called_once_with(self.uploader._schedule_job)
 
         self.uploader.consume_queue.assert_called_once_with(
             mock_process_message, 'service'
@@ -182,13 +174,14 @@ class TestUploadImageService(object):
             )
         ]
 
+    @patch.object(UploadImageService, 'persist_job_config')
     @patch.object(UploadImageService, '_validate_job_description')
     @patch.object(UploadImageService, '_schedule_job')
-    @patch('mash.services.uploader.service.NamedTemporaryFile')
     @patch_open
     def test_add_job(
-        self, mock_open, mock_NamedTemporaryFile,
-        mock_schedule_job, mock_validate_job_description
+        self, mock_open,
+        mock_schedule_job, mock_validate_job_description,
+        mock_persist_job_config
     ):
         job_data = {
             'uploadjob': {
@@ -202,11 +195,6 @@ class TestUploadImageService(object):
                 }
             }
         }
-        tempfile = Mock()
-        tempfile.name = 'tempfile'
-        mock_NamedTemporaryFile.return_value = tempfile
-        context = context_manager()
-        mock_open.return_value = context.context_manager_mock
         job_info = {
             'ok': False
         }
@@ -217,11 +205,11 @@ class TestUploadImageService(object):
         }
         mock_validate_job_description.return_value = job_info
         self.uploader._add_job(job_data)
-        assert context.file_mock.write.called
-        mock_schedule_job.assert_called_once_with('tempfile')
+        mock_schedule_job.assert_called_once_with(job_data['uploadjob'])
         assert mock_validate_job_description.call_args_list == [
             call(job_data), call(job_data)
         ]
+        mock_persist_job_config.assert_called_once_with(job_data['uploadjob'])
 
     @patch('os.remove')
     def test_delete_job(self, mock_os_remove):
@@ -305,10 +293,19 @@ class TestUploadImageService(object):
 
     @patch.object(UploadImageService, '_start_job')
     def test_schedule_job_now(self, mock_start_job):
-        self.uploader._schedule_job('../data/upload_job1.json')
+        data = {
+            "cloud_image_description": "My Image",
+            "cloud_image_name": "ms_image",
+            "ec2": {
+                "launch_ami": "ami-bc5b48d0",
+                "region": "eu-central-1"
+            },
+            "id": "123",
+            "utctime": "now"
+        }
+        self.uploader._schedule_job(data)
         self.uploader.scheduler.add_job.assert_called_once_with(
             mock_start_job, args=[
-                '../data/upload_job1.json',
                 {
                     'id': '123',
                     'cloud_image_name': 'ms_image',
@@ -324,10 +321,16 @@ class TestUploadImageService(object):
 
     @patch.object(UploadImageService, '_start_job')
     def test_schedule_job_always(self, mock_start_job):
-        self.uploader._schedule_job('../data/upload_job2.json')
+        data = {
+            "cloud_image_description": "a",
+            "cloud_image_name": "b",
+            "ec2": {},
+            "id": "123",
+            "utctime": "always"
+        }
+        self.uploader._schedule_job(data)
         self.uploader.scheduler.add_job.assert_called_once_with(
             mock_start_job, args=[
-                '../data/upload_job2.json',
                 {
                     'id': '123',
                     'cloud_image_name': 'b',
@@ -341,14 +344,22 @@ class TestUploadImageService(object):
     @patch.object(UploadImageService, '_bind_queue')
     @patch.object(UploadImageService, '_start_job')
     def test_schedule_job_at_time(self, mock_start_job, mock_bind_queue):
-        self.uploader._schedule_job('../data/upload_job3.json')
+        data = {
+            "cloud_image_description": "a",
+            "cloud_image_name": "b",
+            "ec2": {},
+            "id": "123",
+            "job_file": "job_file",
+            "utctime": "Wed Oct 11 17:50:26 UTC 2017"
+        }
+        self.uploader._schedule_job(data)
         self.uploader.scheduler.add_job.assert_called_once_with(
             mock_start_job, 'date', timezone='utc', args=[
-                '../data/upload_job3.json',
                 {
                     'id': '123',
                     'cloud_image_name': 'b',
                     'cloud_image_description': 'a',
+                    'job_file': 'job_file',
                     'utctime': 'Wed Oct 11 17:50:26 UTC 2017',
                     'ec2': {}
                 }, False
@@ -382,6 +393,7 @@ class TestUploadImageService(object):
             'id': '123',
             'cloud_image_name': 'b',
             'cloud_image_description': 'a',
+            'job_file': 'job_file',
             'utctime': 'now|always',
             'ec2': {}
         }
@@ -390,12 +402,13 @@ class TestUploadImageService(object):
             'credentials_token': 'token',
             'system_image_file': 'image'
         }
-        uploader._start_job('job_file', job, False)
+        uploader._start_job(job, False)
 
         mock_wait_until_ready.assert_called_once_with('123')
         mock_send_job_response.assert_called_once_with(
             '123', 'Waiting for image and credentials data'
         )
+
         mock_UploadImage.assert_called_once_with(
             '123', 'job_file', False, 'ec2', 'token', 'b', 'a',
             custom_uploader_args={}
@@ -410,9 +423,10 @@ class TestUploadImageService(object):
         upload_image.upload.assert_called_once_with()
 
         mock_UploadImage.reset_mock()
+
         mock_send_job_response.reset_mock()
         mock_sleep.side_effect = done_after_one_iteration
-        uploader._start_job('job_file', job, True)
+        uploader._start_job(job, True)
         mock_UploadImage.assert_called_once_with(
             '123', 'job_file', True, 'ec2', 'token', 'b', 'a',
             custom_uploader_args={}


### PR DESCRIPTION
- Merge master
- Updated where unbinding happens. Should be handled by the receiving service.
- Remove unused publish_job method.
- ~~Switch back to two queues and create instance variables to make sure naming is consistent.~~
  - Having multiple consumer callbacks is advantageous and will be added in next release of amqpstorm.
- Cleanup unit tests.

Note: There are two more pull requests that are related to this effort so I think it'd be beneficial to get everything merged before spending too much time testing.

https://github.com/SUSE/mash/pull/53 moving job store methods to base class requires functional changes to all services so they better align with management of config files.

And https://github.com/SUSE/mash/tree/testing-delete is a refactor of testing service to cleanup TODO's and handle the errors as discussed in pipeline.

I did not make any changes to the credential service methods so those are still TBD. For the testing and publisher services I chose to lazy load credentials from each job when it's ready to execute. So I think the credential methods should not be on base. But we can merge this then #51 first and move that to a different discussion/PR.