### PR TITLE
Split out listener queue.

### DIFF
--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -56,6 +56,7 @@ class BaseService(object):
         self.host = host
         self.service_exchange = service_exchange
         self.service_queue = 'service'
+        self.listener_queue = 'listener'
         self.job_document_key = 'job_document'
 
         # setup service data directory
@@ -119,6 +120,7 @@ class BaseService(object):
         if not queue_name:
             queue_name = self.service_queue
         queue = self._get_queue_name(self.service_exchange, queue_name)
+        self._declare_queue(queue)
         self.channel.basic.consume(
             callback=callback, queue=queue
         )
@@ -215,6 +217,11 @@ class BaseService(object):
                 job_config = json.load(conf_file)
 
             callback(job_config)
+
+    def bind_listener_queue(self, routing_key):
+        self.bind_queue(
+            self.service_exchange, routing_key, self.listener_queue
+        )
 
     def unbind_queue(self, queue, exchange, routing_key):
         self.channel.queue.unbind(

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -144,6 +144,13 @@ class TestBaseService(object):
 
         mock_callback.assert_called_once_with({'id': '1'})
 
+    @patch.object(BaseService, 'bind_queue')
+    def test_bind_listener_queue(self, mock_bind_queue):
+        self.service.bind_listener_queue('1')
+        mock_bind_queue.assert_called_once_with(
+            'obs', '1', 'listener'
+        )
+
     def test_unbind_queue(self):
         self.service.unbind_queue(
             'service', 'testing', '1'


### PR DESCRIPTION
AMQPStorm v2.4.0 released with multiple consumer callback support.