### PR TITLE
Update obs job description

### DIFF
--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -106,8 +106,8 @@ class OBSImageBuildResultService(BaseService):
                 extra={'job_id': job_id}
             )
             result = self._add_job(job_data)
-        elif 'obsjob_delete' in job_data and job_data['obsjob_delete']:
-            job_id = job_data['obsjob_delete']
+        elif 'obs_job_delete' in job_data and job_data['obs_job_delete']:
+            job_id = job_data['obs_job_delete']
             self.log.info(
                 'Deleting Job'.format(job_id),
                 extra={'job_id': job_id}
@@ -152,7 +152,7 @@ class OBSImageBuildResultService(BaseService):
 
         delete job description example:
         {
-            "obsjob_delete": "123"
+            "obs_job_delete": "123"
         }
         """
         if job_id not in self.jobs:

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -122,7 +122,7 @@ class TestOBSImageBuildResultService(object):
                 }
             }
         )
-        message.body = '{"obsjob_delete": "4711"}'
+        message.body = '{"obs_job_delete": "4711"}'
         self.obs_result._process_message(message)
         mock_delete_job.assert_called_once_with(
             '4711'


### PR DESCRIPTION
The obs job description for deleting a job has changed
its layout from obsjob_delete to obs_job_delete. This patch
aligns the code to match the example message