### PR TITLE
Add base service methods for credentials requests.

### DIFF
--- a/mash/services/credentials/amazon.py
+++ b/mash/services/credentials/amazon.py
@@ -23,13 +23,15 @@ class CredentialsAmazon(CredentialsBase):
     """
     Implements credentials handling for Amazon
     """
-    def post_init(self):
+    def post_init(
+        self, access_key_id, secret_access_key, ssh_key_name, ssh_private_key
+    ):
         """
         Initialize secret information we need to access Amazon EC2
         """
         self.credentials = {
-            'ssh_key_pair_name': None,
-            'ssh_key_private_key_file': None,
-            'access_key': None,
-            'secret_key': None
+            'access_key_id': access_key_id,
+            'secret_access_key': secret_access_key,
+            'ssh_key_name': ssh_key_name,
+            'ssh_private_key': ssh_private_key
         }

--- a/mash/services/credentials/base.py
+++ b/mash/services/credentials/base.py
@@ -23,13 +23,14 @@ class CredentialsBase(object):
     Base class credentials interface class
     """
     def __init__(self, custom_args=None):
-        self.custom_args = custom_args
-        self.post_init()
+        self.custom_args = custom_args or {}
+        self.post_init(**custom_args)
 
     def post_init(self):
         self.credentials = {}
 
     def set_credentials(self, secret_token):
+        """Deprecated"""
         self.credentials.update(
             jwt.decode(secret_token, 'secret', algorithms=['HS256'])
         )


### PR DESCRIPTION
Methods to create credentials request JWT token, publish request to credentials service, and decode credentials response into a dict of credentials names to credentials objects based on provider.

Note: This is just the code changes for requests and unit tests do not reflect changes.

Also, the decode_credentials method throws exceptions as I think it would be called by the job tasks thread. Thus exceptions can be handled by the scheduler's listener callback.

Added an expiration time for the token to be five minutes from publishing. Not sure if we really need an expiration? Since the data in request + response shouldn't expire as it's static credentials data.