### PR TITLE
Rename error status to failed.

### DIFF
--- a/mash/services/status_levels.py
+++ b/mash/services/status_levels.py
@@ -1,6 +1,6 @@
 SUCCESS = 'success'
-ERROR = 'error'
+FAILED = 'failed'
 EXCEPTION = 'exception'
 OVERDUE = 'overdue'
 DELETE = 'delete'
-UNKOWN = 'unkown'
+UNKOWN = None


### PR DESCRIPTION
Unknown status should evaluate to False aka value of None.

From comment in #78 