### PR TITLE
Use multiple consumer queues.

### DIFF
--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -145,7 +145,7 @@ class TestingService(BaseService):
 
             del self.jobs[job_id]
             self.unbind_queue(
-                self.service_queue, self.service_exchange, job_id
+                self.listener_queue, self.service_exchange, job_id
             )
             self._remove_job_config(job.config_file)
         else:
@@ -224,17 +224,6 @@ class TestingService(BaseService):
             self._publish('jobcreator', 'invalid_config', message)
         except AMQPError:
             self.log.warning('Message not received: {0}'.format(message))
-
-    def _process_message(self, message):
-        """
-        Channel callback, handles incoming messages in queues.
-
-        Send message to proper method based on routing_key.
-        """
-        if message.method['routing_key'] == 'job_document':
-            self._handle_jobs(message)
-        else:
-            self._test_image(message)
 
     def _process_test_result(self, event):
         """
@@ -396,7 +385,10 @@ class TestingService(BaseService):
         Start testing service.
         """
         self.scheduler.start()
-        self.consume_queue(self._process_message)
+        self.consume_queue(self._handle_jobs)
+        self.consume_queue(
+            self._test_image, queue_name=self.listener_queue
+        )
 
         try:
             self.channel.start_consuming()

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -1,5 +1,5 @@
 from pytest import raises
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import call, MagicMock, Mock, patch
 
 from amqpstorm import AMQPError
 from apscheduler.jobstores.base import JobLookupError
@@ -38,6 +38,7 @@ class TestIPATestingService(object):
         self.testing.service_exchange = 'testing'
         self.testing.service_queue = 'service'
         self.testing.job_document_key = 'job_document'
+        self.testing.listener_queue = 'listener'
 
         self.error_message = '{"testing_result": ' \
             '{"id": "1", "status": "error"}}'
@@ -50,10 +51,8 @@ class TestIPATestingService(object):
     @patch.object(TestingService, 'start')
     @patch.object(TestingService, 'restart_jobs')
     @patch('mash.services.testing.service.TestingConfig')
-    @patch.object(TestingService, '_process_message')
     def test_testing_post_init(
-        self, mock_process_message,
-        mock_testing_config, mock_restart_jobs,
+        self, mock_testing_config, mock_restart_jobs,
         mock_start, mock_set_logfile
     ):
         mock_testing_config.return_value = self.config
@@ -155,7 +154,7 @@ class TestIPATestingService(object):
         )
         scheduler.remove_job.assert_called_once_with('1')
         mock_unbind_queue.assert_called_once_with(
-            'service', 'testing', '1'
+            'listener', 'testing', '1'
         )
 
     @patch.object(TestingService, '_delete_job')
@@ -270,20 +269,6 @@ class TestIPATestingService(object):
         self.testing.log.warning.assert_called_once_with(
             'Message not received: {0}'.format('invalid')
         )
-
-    @patch.object(TestingService, '_test_image')
-    def test_testing_process_message_listener_event(self, mock_test_image):
-        self.method['routing_key'] = 'listener_1'
-        self.testing._process_message(self.message)
-
-        mock_test_image.assert_called_once_with(self.message)
-
-    @patch.object(TestingService, '_handle_jobs')
-    def test_testing_process_message_job_document(self, mock_handle_jobs):
-        self.method['routing_key'] = 'job_document'
-        self.testing._process_message(self.message)
-
-        mock_handle_jobs.assert_called_once_with(self.message)
 
     @patch.object(TestingService, '_delete_job')
     @patch.object(TestingService, '_publish')
@@ -573,9 +558,13 @@ class TestIPATestingService(object):
         self.testing.start()
         scheduler.start.assert_called_once_with()
         self.channel.start_consuming.assert_called_once_with()
-        mock_consume_queue.assert_called_once_with(
-            self.testing._process_message
-        )
+        mock_consume_queue.assert_has_calls([
+            call(self.testing._handle_jobs),
+            call(
+                self.testing._test_image,
+                queue_name='listener'
+            )
+        ])
         mock_stop.assert_called_once_with()
 
     @patch.object(TestingService, 'consume_queue')


### PR DESCRIPTION
To organize listener and job doc messages. No need for method to process incoming messages.