### PR TITLE
Add success boolean to log message callback.

### DIFF
--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -75,8 +75,9 @@ class EC2TestingJob(TestingJob):
         for region, result in results.items():
             if result['status'] != SUCCESS:
                 self.send_log(
-                    'Image tests failed in region: {0}.'.format(region)
+                    'Image tests failed in region: {0}.'.format(region),
+                    success=False
                 )
                 if result.get('msg'):
-                    self.send_log(result['msg'])
+                    self.send_log(result['msg'], success=False)
                 self.status = FAILED

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -68,7 +68,7 @@ class TestingJob(object):
             reg: info['image_id'] for reg, info in self.test_regions.items()
         }
 
-    def send_log(self, message):
+    def send_log(self, message, success=True):
         """
         Send a log message to the log callback function.
         """
@@ -78,7 +78,8 @@ class TestingJob(object):
                     self.iteration_count,
                     message
                 ),
-                self.get_metadata()
+                self.get_metadata(),
+                success
             )
 
     def set_log_callback(self, callback):

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -263,11 +263,14 @@ class TestingService(BaseService):
         else:
             message.ack()
 
-    def _log_job_message(self, msg, metadata):
+    def _log_job_message(self, msg, metadata, success=True):
         """
         Callback for job instance to log given message.
         """
-        self.log.info(msg, extra=metadata)
+        if success:
+            self.log.info(msg, extra=metadata)
+        else:
+            self.log.error(msg, extra=metadata)
 
     def _notify_invalid_config(self, message):
         try:

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -60,6 +60,6 @@ class TestEC2TestingJob(object):
         mock_test_image.side_effect = Exception('Tests broken!')
         job._run_tests()
         mock_send_log.assert_has_calls(
-            [call('Image tests failed in region: us-east-1.'),
-             call('Tests broken!')]
+            [call('Image tests failed in region: us-east-1.', success=False),
+             call('Tests broken!', success=False)]
         )

--- a/test/unit/services/testing/job_test.py
+++ b/test/unit/services/testing/job_test.py
@@ -55,7 +55,8 @@ class TestTestingJob(object):
 
         job.log_callback.assert_called_once_with(
             'Pass[1]: Running IPA tests against image.',
-            {'job_id': '1'}
+            {'job_id': '1'},
+            True
         )
 
     def test_invalid_distro(self):

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -275,6 +275,15 @@ class TestIPATestingService(object):
             extra={'job_id': '1'}
         )
 
+        self.testing._log_job_message(
+            'Test error message', {'job_id': '1'}, success=False
+        )
+
+        self.testing.log.error.assert_called_once_with(
+            'Test error message',
+            extra={'job_id': '1'}
+        )
+
     @patch.object(TestingService, '_publish')
     def test_testing_notify(self, mock_publish):
         self.testing._notify_invalid_config('invalid')


### PR DESCRIPTION
Messages marked as not successful are logged as error not info.

#111 