### PR TITLE
Do not exit on exception.

### DIFF
--- a/mash/services/replication/job.py
+++ b/mash/services/replication/job.py
@@ -58,14 +58,15 @@ class ReplicationJob(object):
         self.iteration_count += 1
         self._replicate()
 
-    def send_log(self, message):
+    def send_log(self, message, success=True):
         if self.log_callback:
             self.log_callback(
                 'Pass[{0}]: {1}'.format(
                     self.iteration_count,
                     message
                 ),
-                self.get_metadata()
+                self.get_metadata(),
+                success
             )
 
     def set_log_callback(self, callback):

--- a/test/unit/services/replication/job_test.py
+++ b/test/unit/services/replication/job_test.py
@@ -41,7 +41,8 @@ class TestReplicationJob(object):
 
         callback.assert_called_once_with(
             'Pass[0]: Starting replicate.',
-            {'job_id': '1'}
+            {'job_id': '1'},
+            True
         )
 
     def test_set_log_callback(self):


### PR DESCRIPTION
- If a region raises exception in replication log the error and
continue.
- Suppress flake8 warning, closing tag matches indent.
- Allow for error level messages in send log.