### PR TITLE
Don't delete creds job if utctime is always.

### DIFF
--- a/examples/messages/credentials_job.json
+++ b/examples/messages/credentials_job.json
@@ -5,6 +5,7 @@
         "provider_accounts": ["test-aws", "test-aws-cn"],
         "requesting_user": "test-aws",
         "last_service": "pint",
+        "utctime": "now",
         "test_credentials": {
 	        "access_key_id": "123456",
 	        "secret_access_key": "654321",

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -276,7 +276,8 @@ class CredentialsService(BaseService):
             message = json.dumps({'jwt_token': credentials_response.decode()})
             self._publish_credentials_response(message, payload['iss'])
 
-            if job['last_service'] == payload['iss']:
+            if job['utctime'] != 'always' and \
+                    job['last_service'] == payload['iss']:
                 self._delete_job(job['id'])
         else:
             self._send_control_response(

--- a/test/unit/services/credentials/service_test.py
+++ b/test/unit/services/credentials/service_test.py
@@ -319,7 +319,7 @@ class TestCredentialsService(object):
         self, mock_publish_credentials_response, mock_get_cred_response,
         mock_delete_job
     ):
-        job = {'id': '1', 'last_service': 'pint'}
+        job = {'id': '1', 'last_service': 'pint', 'utctime': 'now'}
         self.service.jobs = {'1': job}
 
         mock_get_cred_response.return_value = b'response'


### PR DESCRIPTION
I think we want utctime in credentials job doc right?

That way we can leave the job alone if 'always' job. Otherwise on last service the job is deleted. So as discussed an always job must be explicitly deleted using delete message from job creator.