### PR TITLE
Create key pair if it does not exist

### DIFF
--- a/mash/services/testing/ipa_helper.py
+++ b/mash/services/testing/ipa_helper.py
@@ -20,8 +20,10 @@ import logging
 import threading
 
 from ipa.ipa_controller import test_image
+from ipa.ipa_utils import generate_public_ssh_key
 
 from mash.services.status_levels import EXCEPTION, FAILED, SUCCESS
+from mash.utils.ec2 import get_client
 
 
 def ipa_test(
@@ -30,9 +32,17 @@ def ipa_test(
     ssh_key_name=None, ssh_private_key=None, ssh_user=None, tests=None
 ):
     name = threading.current_thread().getName()
-    # TODO determine if we want to handle key-pair issues manually or
-    # automagically with temp key files.
     try:
+        client = get_client('ec2', access_key_id, secret_access_key, region)
+        try:
+            client.describe_key_pairs(KeyNames=[ssh_key_name])
+        except Exception:
+            # If key pair does not exist create it in the region.
+            pub_key = generate_public_ssh_key(ssh_private_key)
+            client.import_key_pair(
+                KeyName=ssh_key_name, PublicKeyMaterial=pub_key
+            )
+
         status, result = test_image(
             provider.upper(),  # TODO remove uppercase when IPA update released
             access_key_id=access_key_id,

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, patch
+from unittest.mock import call, Mock, patch
 
 from mash.services.testing.ec2_job import EC2TestingJob
 
@@ -13,9 +13,20 @@ class TestEC2TestingJob(object):
             'utctime': 'now',
         }
 
+    @patch('mash.services.testing.ipa_helper.generate_public_ssh_key')
+    @patch('mash.services.testing.ipa_helper.get_client')
     @patch('mash.services.testing.ipa_helper.test_image')
     @patch.object(EC2TestingJob, 'send_log')
-    def test_testing_run_test(self, mock_send_log, mock_test_image):
+    def test_testing_run_test(
+        self, mock_send_log, mock_test_image, mock_get_client,
+        mock_generate_ssh_key
+    ):
+        client = Mock()
+        client.describe_key_pairs.side_effect = Exception('Key not found.')
+        mock_get_client.return_value = client
+
+        mock_generate_ssh_key.return_value = 'fakekey'
+
         mock_test_image.return_value = (
             0,
             {
@@ -31,28 +42,34 @@ class TestEC2TestingJob(object):
         job = EC2TestingJob(**self.job_config)
         job.credentials = {
             'test-aws': {
-                'access_key_id': None,
-                'secret_access_key': None,
-                'ssh_key_name': None,
-                'ssh_private_key': None
+                'access_key_id': '123',
+                'secret_access_key': '321',
+                'ssh_key_name': 'my-key',
+                'ssh_private_key': 'my-key.file'
             }
         }
         job.update_test_regions({'us-east-1': 'ami-123'})
         job._run_tests()
 
+        client.describe_key_pairs.assert_called_once_with(
+            KeyNames=['my-key']
+        )
+        client.import_key_pair.assert_called_once_with(
+            KeyName='my-key', PublicKeyMaterial='fakekey'
+        )
         mock_test_image.assert_called_once_with(
             'EC2',
-            access_key_id=None,
             cleanup=True,
+            access_key_id='123',
             desc=job.description,
             distro='SLES',
             image_id='ami-123',
             instance_type=job.instance_type,
             log_level=30,
             region='us-east-1',
-            secret_access_key=None,
-            ssh_key_name=None,
-            ssh_private_key=None,
+            secret_access_key='321',
+            ssh_key_name='my-key',
+            ssh_private_key='my-key.file',
             ssh_user='ec2-user',
             tests=['test_stuff']
         )


### PR DESCRIPTION
If key pair does not exist create it in the region based on the provided private key.

I think this is much better then temp keys since we are given the information that is expected. Thus if it's not as expected we can fix it. No need to create temp keys on every test run.