### PR TITLE
No routing key use for uploader

### DIFF
--- a/examples/messages/credentials_job.json
+++ b/examples/messages/credentials_job.json
@@ -4,6 +4,12 @@
         "provider": "ec2",
         "provider_accounts": ["test-aws", "test-aws-cn"],
         "requesting_user": "test-aws",
-        "last_service": "pint"
+        "last_service": "pint",
+        "test_credentials": {
+	        "access_key_id": "123456",
+	        "secret_access_key": "654321",
+	        "ssh_key_name": "my-key",
+	        "ssh_private_key": "my-key.pem"
+        }
     }
 }

--- a/mash/services/obs/build_result.py
+++ b/mash/services/obs/build_result.py
@@ -222,9 +222,11 @@ class OBSImageBuildResult(object):
         if self.result_callback:
             self.result_callback(
                 self.job_id, {
-                    'id': self.job_id,
-                    'image_file': self.image_status['image_source'],
-                    'status': job_status
+                    'obs_result': {
+                        'id': self.job_id,
+                        'image_file': self.image_status['image_source'],
+                        'status': job_status
+                    }
                 }
             )
 

--- a/mash/services/uploader/cloud/amazon.py
+++ b/mash/services/uploader/cloud/amazon.py
@@ -54,13 +54,23 @@ class UploadAmazon(UploadBase):
             'running_id': None,
             'secret_key': None
         }
-        self.ec2_upload_parameters.update(
-            self.credentials
-        )
+
+        self.ec2_upload_parameters['access_key'] = \
+            self.credentials['access_key_id']
+        self.ec2_upload_parameters['secret_key'] = \
+            self.credentials['secret_access_key']
+        self.ec2_upload_parameters['ssh_key_pair_name'] = \
+            self.credentials['ssh_key_name']
+        self.ec2_upload_parameters['ssh_key_private_key_file'] = \
+            self.credentials['ssh_private_key']
+
         if self.custom_args:
             if 'region' in self.custom_args:
                 self.region = self.custom_args['region']
                 del self.custom_args['region']
+
+            if 'account' in self.custom_args:
+                del self.custom_args['account']
 
             self.ec2_upload_parameters.update(self.custom_args)
 

--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -48,16 +48,11 @@ class UploadImage(object):
     * :attr:`custom_uploader_args`
         dictionary of parameters for the used upload tool
         specific to the selected cloud and uploader class
-
-    * :attr:`custom_credentials_args`
-        dictionary of parameters for the instance handling
-        credentials. specific to the selected cloud and
-        credentials class
     """
     def __init__(
         self, job_id, job_file, nonstop, csp_name, credentials_token,
         cloud_image_name, cloud_image_description, last_upload_region,
-        custom_uploader_args=None, custom_credentials_args=None
+        custom_uploader_args=None
     ):
         self.job_id = job_id
         self.job_file = job_file
@@ -67,7 +62,6 @@ class UploadImage(object):
         self.cloud_image_name = cloud_image_name
         self.cloud_image_description = cloud_image_description
         self.custom_uploader_args = custom_uploader_args
-        self.custom_credentials_args = custom_credentials_args
         self.last_upload_region = last_upload_region
 
         self.credentials_token = credentials_token
@@ -96,16 +90,16 @@ class UploadImage(object):
         if self.system_image_file:
             self.iteration_count += 1
             self._log_callback(
-                'Uploading image to {0}: {1}'.format(
-                    self.csp_name, self.system_image_file
+                'Uploading image to {0}: {1}:{2}'.format(
+                    self.csp_name, self.system_image_file,
+                    self.custom_uploader_args
                 )
             )
             self.uploader = Upload(
                 self.csp_name, self.system_image_file,
                 self.cloud_image_name, self.cloud_image_description,
                 self.credentials_token,
-                self.custom_uploader_args,
-                self.custom_credentials_args
+                self.custom_uploader_args
             )
             try:
                 (self.upload_region, self.cloud_image_id) = \

--- a/test/unit/services/obs/build_result_test.py
+++ b/test/unit/services/obs/build_result_test.py
@@ -70,7 +70,10 @@ class TestOBSImageBuildResult(object):
         self.obs_result._result_callback()
         self.obs_result.result_callback.assert_called_once_with(
             '815', {
-                'id': '815', 'image_file': ['image', 'sum'], 'status': 'success'
+                'obs_result': {
+                    'id': '815',
+                    'image_file': ['image', 'sum'], 'status': 'success'
+                }
             }
         )
 

--- a/test/unit/services/uploader/cloud/amazon_test.py
+++ b/test/unit/services/uploader/cloud/amazon_test.py
@@ -13,17 +13,18 @@ class TestUploadAmazon(object):
         mash.services.uploader.cloud.amazon.EC2ImageUploader = self.ec2
         self.credentials = Mock()
         self.credentials = {
-            'ssh_key_pair_name': 'name',
-            'ssh_key_private_key_file': '/some/path/to/private/key',
-            'access_key': 'access-key',
-            'secret_key': 'secret-access-key'
+            'ssh_key_name': 'name',
+            'ssh_private_key': '/some/path/to/private/key',
+            'access_key_id': 'access-key',
+            'secret_access_key': 'secret-access-key'
         }
         custom_args = {
             'image_arch': 'x86_64',
             'launch_ami': 'ami-bc5b48d0',
             'sriov_type': 'simple',
             'ena_support': True,
-            'region': 'us-east-1'
+            'region': 'us-east-1',
+            'account': 'mash-account'
         }
         self.uploader = UploadAmazon(
             self.credentials, 'file', 'name', 'description', custom_args

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -130,14 +130,14 @@ class TestUploadImageService(object):
         self, mock_decode_credentials, mock_send_control_response
     ):
         message = Mock()
-        message.method = {'routing_key': '123'}
-        message.body = '{"image_file": ["image", "sum"], "status": "success"}'
+        message.body = '{"obs_result": {"id": "123", ' + \
+            '"image_file": ["image", "sum"], "status": "success"}}'
         self.uploader._process_message(message)
         assert self.uploader.jobs['123']['system_image_file'] == 'image'
         message.body = '{"jwt_token": {}}'
+        mock_decode_credentials.return_value = {'id': '123', 'credentials': {}}
         self.uploader._process_message(message)
-        assert self.uploader.jobs['123']['credentials'] == \
-            mock_decode_credentials.return_value
+        assert self.uploader.jobs['123']['credentials'] == {}
         assert self.uploader.jobs['123']['ready'] is True
 
     @patch.object(UploadImageService, '_add_job')
@@ -146,7 +146,6 @@ class TestUploadImageService(object):
         self, mock_send_control_response, mock_add_job
     ):
         message = Mock()
-        message.method = {'routing_key': 'job_document'}
         message.body = '{"uploader_job": {"id": "123", ' + \
             '"utctime": "now", "cloud_image_name": "name", ' + \
             '"image_description": "description", ' + \
@@ -183,8 +182,7 @@ class TestUploadImageService(object):
                     'message':
                         "No idea what to do with: {'unknown_command': '4711'}",
                     'ok': False
-                },
-                None
+                }
             ),
             call(
                 {


### PR DESCRIPTION
Delete use of routing_key in uploader service
    
All information to classify a message is part of the message itself
Thus there is no reason to check on the routing key.

While testing the pipeline I stumbled over a couple of smaller issues for which I have created extra commits to this pull request which can be reviewed on a commit base
