### PR TITLE
Remove ssh key name requirement from testing.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -13,3 +13,5 @@ non_cred_services:
   - obs
 obs:
   download_directory: /var/tmp/mash/images
+testing:
+  ssh_private_key_file: /etc/mash/testing_key

--- a/mash/services/testing/config.py
+++ b/mash/services/testing/config.py
@@ -16,6 +16,7 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from mash.mash_exceptions import MashConfigException
 from mash.services.base_config import BaseConfig
 
 
@@ -32,3 +33,21 @@ class TestingConfig(BaseConfig):
 
     def __init__(self, config_file=None):
         super(TestingConfig, self).__init__(config_file)
+
+    def get_ssh_private_key_file(self):
+        """
+        Return the path to the ssh private key file.
+
+        :rtype: string
+        """
+        private_key_file = self._get_attribute(
+            attribute='ssh_private_key_file', element='testing'
+        )
+
+        if not private_key_file:
+            raise MashConfigException(
+                'ssh_private_key_file is required in configuration file for '
+                'testing service.'
+            )
+
+        return private_key_file

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -30,12 +30,12 @@ class EC2TestingJob(TestingJob):
     __test__ = False
 
     def __init__(
-        self, id, provider, test_regions, tests, utctime, job_file=None,
-        credentials=None, description=None, distro=None, instance_type=None,
-        ssh_user='ec2-user'
+        self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
+        job_file=None, credentials=None, description=None, distro=None,
+        instance_type=None, ssh_user='ec2-user'
     ):
         super(EC2TestingJob, self).__init__(
-            id, provider, test_regions, tests, utctime,
+            id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,
             instance_type=instance_type
         )
@@ -59,8 +59,7 @@ class EC2TestingJob(TestingJob):
                     'instance_type': self.instance_type,
                     'region': region,
                     'secret_access_key': creds['secret_access_key'],
-                    'ssh_key_name': creds['ssh_key_name'],
-                    'ssh_private_key': creds['ssh_private_key'],
+                    'ssh_private_key': self.ssh_private_key_file,
                     'ssh_user': self.ssh_user,
                     'tests': self.tests
                 }

--- a/mash/services/testing/ipa_helper.py
+++ b/mash/services/testing/ipa_helper.py
@@ -20,29 +20,17 @@ import logging
 import threading
 
 from ipa.ipa_controller import test_image
-from ipa.ipa_utils import generate_public_ssh_key
 
 from mash.services.status_levels import EXCEPTION, FAILED, SUCCESS
-from mash.utils.ec2 import get_client
 
 
 def ipa_test(
     results, provider=None, access_key_id=None, description=None, distro=None,
     image_id=None, instance_type=None, region=None, secret_access_key=None,
-    ssh_key_name=None, ssh_private_key=None, ssh_user=None, tests=None
+    ssh_private_key=None, ssh_user=None, tests=None
 ):
     name = threading.current_thread().getName()
     try:
-        client = get_client('ec2', access_key_id, secret_access_key, region)
-        try:
-            client.describe_key_pairs(KeyNames=[ssh_key_name])
-        except Exception:
-            # If key pair does not exist create it in the region.
-            pub_key = generate_public_ssh_key(ssh_private_key)
-            client.import_key_pair(
-                KeyName=ssh_key_name, PublicKeyMaterial=pub_key
-            )
-
         status, result = test_image(
             provider.upper(),  # TODO remove uppercase when IPA update released
             access_key_id=access_key_id,
@@ -54,7 +42,6 @@ def ipa_test(
             log_level=logging.WARNING,
             region=region,
             secret_access_key=secret_access_key,
-            ssh_key_name=ssh_key_name,
             ssh_private_key=ssh_private_key,
             ssh_user=ssh_user,
             tests=tests

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -30,8 +30,8 @@ class TestingJob(object):
     __test__ = False
 
     def __init__(
-        self, id, provider, test_regions, tests, utctime, job_file=None,
-        description=None, distro=None, instance_type=None
+        self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
+        job_file=None, description=None, distro=None, instance_type=None
     ):
         self.cloud_image_name = None
         self.job_file = job_file
@@ -44,6 +44,7 @@ class TestingJob(object):
         self.log_callback = None
         self.provider = self.validate_provider(provider)
         self.status = UNKOWN
+        self.ssh_private_key_file = ssh_private_key_file
         self.test_regions = self.validate_test_regions(test_regions)
         self.tests = self.validate_tests(tests)
         self.utctime = self.validate_timestamp(utctime)

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -48,6 +48,7 @@ class TestingService(BaseService):
         """
         self.config = TestingConfig()
         self.set_logfile(self.config.get_log_file(self.service_exchange))
+        self.ssh_private_key_file = self.config.get_ssh_private_key_file()
 
         self.jobs = {}
 
@@ -105,6 +106,7 @@ class TestingService(BaseService):
         3. Store config file if not stored already.
         4. Bind to job listener queue.
         """
+        job_config['ssh_private_key_file'] = self.ssh_private_key_file
         try:
             job = job_class(**job_config)
         except Exception as e:

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -9,3 +9,5 @@ services:
   - pint
 non_cred_services:
   - obs
+testing:
+  ssh_private_key_file: /etc/mash/testing_key

--- a/test/unit/services/testing/config_test.py
+++ b/test/unit/services/testing/config_test.py
@@ -1,13 +1,23 @@
+from pytest import raises
+
+from mash.mash_exceptions import MashConfigException
 from mash.services.testing.config import TestingConfig
 
 
 class TestTestingConfig(object):
     def setup(self):
-        self.empty_config = TestingConfig('../data/empty_testing_config.yml')
-
-    def test_config_data(self):
-        assert self.empty_config.config_data
+        self.empty_config = TestingConfig('../data/empty_mash_config.yaml')
+        self.config = TestingConfig('../data/mash_config.yaml')
 
     def test_get_log_file(self):
         assert self.empty_config.get_log_file('testing') == \
             '/var/log/mash/testing_service.log'
+
+    def test_get_ssh_private_key_file(self):
+        assert self.config.get_ssh_private_key_file() == \
+            '/etc/mash/testing_key'
+
+        with raises(MashConfigException) as error:
+            self.empty_config.get_ssh_private_key_file()
+
+        assert str(error.value)

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, Mock, patch
+from unittest.mock import call, patch
 
 from mash.services.testing.ec2_job import EC2TestingJob
 
@@ -8,25 +8,17 @@ class TestEC2TestingJob(object):
         self.job_config = {
             'id': '1',
             'provider': 'ec2',
+            'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'us-east-1': 'test-aws'},
             'tests': 'test_stuff',
             'utctime': 'now',
         }
 
-    @patch('mash.services.testing.ipa_helper.generate_public_ssh_key')
-    @patch('mash.services.testing.ipa_helper.get_client')
     @patch('mash.services.testing.ipa_helper.test_image')
     @patch.object(EC2TestingJob, 'send_log')
     def test_testing_run_test(
-        self, mock_send_log, mock_test_image, mock_get_client,
-        mock_generate_ssh_key
+        self, mock_send_log, mock_test_image
     ):
-        client = Mock()
-        client.describe_key_pairs.side_effect = Exception('Key not found.')
-        mock_get_client.return_value = client
-
-        mock_generate_ssh_key.return_value = 'fakekey'
-
         mock_test_image.return_value = (
             0,
             {
@@ -43,20 +35,12 @@ class TestEC2TestingJob(object):
         job.credentials = {
             'test-aws': {
                 'access_key_id': '123',
-                'secret_access_key': '321',
-                'ssh_key_name': 'my-key',
-                'ssh_private_key': 'my-key.file'
+                'secret_access_key': '321'
             }
         }
         job.update_test_regions({'us-east-1': 'ami-123'})
         job._run_tests()
 
-        client.describe_key_pairs.assert_called_once_with(
-            KeyNames=['my-key']
-        )
-        client.import_key_pair.assert_called_once_with(
-            KeyName='my-key', PublicKeyMaterial='fakekey'
-        )
         mock_test_image.assert_called_once_with(
             'EC2',
             cleanup=True,
@@ -68,8 +52,7 @@ class TestEC2TestingJob(object):
             log_level=30,
             region='us-east-1',
             secret_access_key='321',
-            ssh_key_name='my-key',
-            ssh_private_key='my-key.file',
+            ssh_private_key='private_ssh_key.file',
             ssh_user='ec2-user',
             tests=['test_stuff']
         )

--- a/test/unit/services/testing/job_test.py
+++ b/test/unit/services/testing/job_test.py
@@ -10,6 +10,7 @@ class TestTestingJob(object):
         self.job_config = {
             'id': '1',
             'provider': 'ec2',
+            'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'us-east-1': 'test-aws'},
             'tests': 'test_stuff',
             'utctime': 'now'

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -39,6 +39,7 @@ class TestIPATestingService(object):
         self.testing.service_queue = 'service'
         self.testing.job_document_key = 'job_document'
         self.testing.listener_queue = 'listener'
+        self.testing.ssh_private_key_file = 'private_ssh_key.file'
 
         self.error_message = '{"testing_result": ' \
             '{"id": "1", "status": "error"}}'
@@ -117,7 +118,9 @@ class TestIPATestingService(object):
         job_config = {'id': '1', 'provider': 'ec2'}
         self.testing._create_job(job_class, job_config)
 
-        job_class.assert_called_once_with(id='1', provider='ec2')
+        job_class.assert_called_once_with(
+            id='1', provider='ec2', ssh_private_key_file='private_ssh_key.file'
+        )
         job.set_log_callback.assert_called_once_with(
             self.testing._log_job_message
         )


### PR DESCRIPTION
IPA [will add](https://github.com/SUSE/ipa/pull/68) public key to EC2 instance based on private key file using cloud init script.

Private key file will be provided as a configuration item in MASH config file.