### PR TITLE
Rename source_regions in replication job doc.

### DIFF
--- a/examples/messages/replication_job.json
+++ b/examples/messages/replication_job.json
@@ -4,7 +4,7 @@
         "image_description": "My Image",
         "provider": "ec2",
         "utctime": "now",
-        "source_regions": {
+        "replication_regions": {
             "us-east-1": {
                 "account": "test-aws",
                 "target_regions": ["us-east-2", "us-west-2", "eu-west-3"]

--- a/examples/messages/replication_job.json
+++ b/examples/messages/replication_job.json
@@ -4,7 +4,7 @@
         "image_description": "My Image",
         "provider": "ec2",
         "utctime": "now",
-        "replication_regions": {
+        "replication_source_regions": {
             "us-east-1": {
                 "account": "test-aws",
                 "target_regions": ["us-east-2", "us-west-2", "eu-west-3"]

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -32,8 +32,8 @@ class EC2ReplicationJob(ReplicationJob):
     """
 
     def __init__(
-        self, id, image_description, provider, utctime, replication_regions,
-        cloud_image_name=None, job_file=None
+        self, id, image_description, provider, utctime,
+        replication_source_regions, cloud_image_name=None, job_file=None
     ):
         super(EC2ReplicationJob, self).__init__(
             id, provider, utctime, job_file=job_file
@@ -44,9 +44,10 @@ class EC2ReplicationJob(ReplicationJob):
         self.job_file = job_file
         self.source_region_results = None
         self.source_regions = None
-        self.replication_regions = self.validate_replication_regions(
-            replication_regions
-        )
+        self.replication_source_regions = \
+            self.validate_replication_source_regions(
+                replication_source_regions
+            )
 
     def _replicate(self):
         """
@@ -55,7 +56,7 @@ class EC2ReplicationJob(ReplicationJob):
         self.status = SUCCESS
         self.source_region_results = defaultdict(dict)
 
-        for source_region, reg_info in self.replication_regions.items():
+        for source_region, reg_info in self.replication_source_regions.items():
             credential = self.credentials[reg_info['account']]
 
             self.send_log(
@@ -157,16 +158,16 @@ class EC2ReplicationJob(ReplicationJob):
                 return True
         return False
 
-    def validate_replication_regions(self, replication_regions):
+    def validate_replication_source_regions(self, replication_source_regions):
         """
-        Validate replication_regions attribute is correct format.
+        Validate replication_source_regions attribute is correct format.
 
         Must be a dictionary mapping regions to accounts and target_regions
         list.
 
         {'us-east-1': {'account': 'test-aws', 'target_regions': ['us-east-2']}}
         """
-        for region, reg_info in replication_regions.items():
+        for region, reg_info in replication_source_regions.items():
             if not reg_info.get('account'):
                 raise MashReplicationException(
                     'Source region {0} missing account name.'.format(region)
@@ -175,4 +176,4 @@ class EC2ReplicationJob(ReplicationJob):
                 raise MashReplicationException(
                     'Source region {0} missing target regions.'.format(region)
                 )
-        return replication_regions
+        return replication_source_regions

--- a/mash/services/replication/job.py
+++ b/mash/services/replication/job.py
@@ -30,7 +30,6 @@ class ReplicationJob(object):
     """
 
     def __init__(self, id, provider, utctime, job_file=None):
-        self.image_id = None
         self.iteration_count = 0
         self.id = id
         self.job_file = job_file
@@ -51,9 +50,9 @@ class ReplicationJob(object):
         """
         return {'job_id': self.id}
 
-    def replicate_image(self, host):
+    def replicate_image(self):
         """
-        Get credentials and replicate image.
+        Replicate image.
         """
         self.iteration_count += 1
         self._replicate()

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -308,7 +308,7 @@ class ReplicationService(BaseService):
         Publish image for job that matches job_id
         """
         job = self.jobs[job_id]
-        job.replicate_image(host=self.host)
+        job.replicate_image()
 
     def _publish_message(self, job):
         """
@@ -358,7 +358,8 @@ class ReplicationService(BaseService):
         Validate the job has the required attributes.
         """
         required = [
-            'id', 'image_description', 'provider', 'utctime', 'source_regions'
+            'id', 'image_description', 'provider',
+            'utctime', 'replication_regions'
         ]
         for attr in required:
             if attr not in job_config:
@@ -400,18 +401,13 @@ class ReplicationService(BaseService):
             return None
         else:
             # Required args
-            for attr in ['image_id', 'image_name', 'source_region']:
+            for attr in ['cloud_image_name', 'source_regions']:
                 if attr not in listener_msg:
                     self.log.error(
                         '{0} is required in testing result.'.format(attr)
                     )
                     return None
                 else:
-                    setattr(job, attr, listener_msg[attr])
-
-            # Optional args
-            for attr in ['image_description', 'regions']:
-                if attr in listener_msg:
                     setattr(job, attr, listener_msg[attr])
 
         return job

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -350,7 +350,7 @@ class ReplicationService(BaseService):
         """
         required = [
             'id', 'image_description', 'provider',
-            'utctime', 'replication_regions'
+            'utctime', 'replication_source_regions'
         ]
         for attr in required:
             if attr not in job_config:

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -14,7 +14,7 @@ class TestEC2ReplicationJob(object):
             'image_description': 'My image',
             'provider': 'ec2',
             'utctime': 'now',
-            "replication_regions": {
+            "replication_source_regions": {
                 "us-east-1": {
                     "account": "test-aws",
                     "target_regions": ["us-east-2"]
@@ -172,17 +172,17 @@ class TestEC2ReplicationJob(object):
 
         assert result
 
-    def test_replicate_validate_replication_regions_exceptions(self):
+    def test_replicate_validate_replication_source_regions_exceptions(self):
         source_regions = {'us-east-2': {}}
 
         msg = 'Source region us-east-2 missing account name.'
         with raises(MashReplicationException) as error:
-            self.job.validate_replication_regions(source_regions)
+            self.job.validate_replication_source_regions(source_regions)
         assert msg == str(error.value)
 
         source_regions = {'us-east-2': {'account': 'test-aws'}}
 
         msg = 'Source region us-east-2 missing target regions.'
         with raises(MashReplicationException) as error:
-            self.job.validate_replication_regions(source_regions)
+            self.job.validate_replication_source_regions(source_regions)
         assert msg == str(error.value)

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 
 from mash.mash_exceptions import MashReplicationException
 from mash.services.status_levels import FAILED
-from mash.services.credentials.amazon import CredentialsAmazon
 from mash.services.replication.ec2_job import EC2ReplicationJob
 from mash.services.replication.job import ReplicationJob
 
@@ -15,7 +14,7 @@ class TestEC2ReplicationJob(object):
             'image_description': 'My image',
             'provider': 'ec2',
             'utctime': 'now',
-            "source_regions": {
+            "replication_regions": {
                 "us-east-1": {
                     "account": "test-aws",
                     "target_regions": ["us-east-2"]
@@ -23,16 +22,12 @@ class TestEC2ReplicationJob(object):
             }
         }
         self.job = EC2ReplicationJob(**self.job_config)
-        self.job.update_source_regions({'us-east-1': 'ami-12345'})
 
-        args = {
-            'access_key_id': '123456',
-            'secret_access_key': '654321',
-            'ssh_key_name': 'my-key',
-            'ssh_private_key': 'my-key.pem'
-        }
         self.job.credentials = {
-            "test-aws": CredentialsAmazon(custom_args=args)
+            "test-aws": {
+                'access_key_id': '123456',
+                'secret_access_key': '654321'
+            }
         }
 
     @patch('mash.services.replication.ec2_job.time')
@@ -45,6 +40,7 @@ class TestEC2ReplicationJob(object):
     ):
         mock_replicate_to_region.return_value = 'ami-54321'
 
+        self.job.source_regions = {'us-east-1': 'ami-12345'}
         self.job._replicate()
 
         mock_send_log.assert_called_once_with(
@@ -70,14 +66,11 @@ class TestEC2ReplicationJob(object):
         mock_get_client.return_value = client
         mock_image_exists.return_value = False
 
-        credential = Mock()
-        credential.access_key_id = '123456'
-        credential.secret_access_key = '654321'
-
         self.job.cloud_image_name = 'My image'
 
         self.job._replicate_to_region(
-            credential, 'ami-12345', 'us-east-1', 'us-east-2'
+            self.job.credentials['test-aws'],
+            'ami-12345', 'us-east-1', 'us-east-2'
         )
 
         mock_get_client.assert_called_once_with(
@@ -103,15 +96,12 @@ class TestEC2ReplicationJob(object):
         mock_get_client.return_value = client
         mock_image_exists.return_value = False
 
-        credential = Mock()
-        credential.access_key_id = '123456'
-        credential.secret_access_key = '654321'
-
         msg = 'There was an error replicating image to us-east-2. ' \
             'Error copying image!'
         with raises(MashReplicationException) as e:
             self.job._replicate_to_region(
-                credential, 'ami-12345', 'us-east-1', 'us-east-2'
+                self.job.credentials['test-aws'],
+                'ami-12345', 'us-east-1', 'us-east-2'
             )
 
         assert msg == str(e.value)
@@ -123,11 +113,9 @@ class TestEC2ReplicationJob(object):
         client.get_waiter.return_value = waiter
         mock_get_client.return_value = client
 
-        credential = Mock()
-        credential.access_key_id = '123456'
-        credential.secret_access_key = '654321'
-
-        self.job._wait_on_image(credential, 'ami-54321', 'us-east-2')
+        self.job._wait_on_image(
+            self.job.credentials['test-aws'], 'ami-54321', 'us-east-2'
+        )
 
         mock_get_client.assert_called_once_with(
             'ec2', '123456', '654321', 'us-east-2'
@@ -147,11 +135,9 @@ class TestEC2ReplicationJob(object):
         client.get_waiter.side_effect = Exception('Error copying image!')
         mock_get_client.return_value = client
 
-        credential = Mock()
-        credential.access_key_id = '123456'
-        credential.secret_access_key = '654321'
-
-        self.job._wait_on_image(credential, 'awi-54321', 'us-east-2')
+        self.job._wait_on_image(
+            self.job.credentials['test-aws'], 'awi-54321', 'us-east-2'
+        )
 
         mock_send_log.assert_called_once_with(
             'There was an error replicating image to us-east-2. '
@@ -186,17 +172,17 @@ class TestEC2ReplicationJob(object):
 
         assert result
 
-    def test_replicate_validate_source_regions_exceptions(self):
+    def test_replicate_validate_replication_regions_exceptions(self):
         source_regions = {'us-east-2': {}}
 
         msg = 'Source region us-east-2 missing account name.'
         with raises(MashReplicationException) as error:
-            self.job.validate_source_regions(source_regions)
+            self.job.validate_replication_regions(source_regions)
         assert msg == str(error.value)
 
         source_regions = {'us-east-2': {'account': 'test-aws'}}
 
         msg = 'Source region us-east-2 missing target regions.'
         with raises(MashReplicationException) as error:
-            self.job.validate_source_regions(source_regions)
+            self.job.validate_replication_regions(source_regions)
         assert msg == str(error.value)

--- a/test/unit/services/replication/job_test.py
+++ b/test/unit/services/replication/job_test.py
@@ -57,7 +57,7 @@ class TestReplicationJob(object):
     def test_replicate_image(self, mock_replicate):
         job = ReplicationJob(**self.job_config)
         job.log_callback = Mock()
-        job.replicate_image('localhost')
+        job.replicate_image()
 
         mock_replicate.assert_called_once_with()
 

--- a/test/unit/services/replication/service_test.py
+++ b/test/unit/services/replication/service_test.py
@@ -344,7 +344,7 @@ class TestReplicationService(object):
 
         self.message.body = '{"replication_job": {"id": "1", ' \
             '"image_description": "My image", "provider": "EC2", ' \
-            '"utctime": "now", "replication_regions": {"us-east-1": {' \
+            '"utctime": "now", "replication_source_regions": {"us-east-1": {' \
             '"account": "test-aws", "target_regions": ' \
             '["us-east-2", "us-west-2", "eu-west-3"]}}}}'
         self.replication._handle_service_message(self.message)
@@ -352,7 +352,8 @@ class TestReplicationService(object):
         mock_add_job.assert_called_once_with(
             {
                 'id': '1', 'image_description': 'My image',
-                'provider': 'EC2', 'utctime': 'now', 'replication_regions': {
+                'provider': 'EC2', 'utctime': 'now',
+                'replication_source_regions': {
                     'us-east-1': {
                         'account': 'test-aws', 'target_regions': [
                             "us-east-2", "us-west-2", "eu-west-3"


### PR DESCRIPTION
- Rename to replication_source_regions to be consistent with other msgs.
- Remove unused image_id and ssh_user args from replication jobs.
- Update credential handling per cred service changes.
- Cleanup validation args in replication service.