### PR TITLE
Simplify testing args.

### DIFF
--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -47,15 +47,15 @@ class EC2TestingJob(TestingJob):
         """
         results = {}
         jobs = []
-        for region, info in self.test_regions.items():
-            creds = self.credentials[info['account']]
+        for region, account in self.test_regions.items():
+            creds = self.credentials[account]
             process = Thread(
                 name=region, target=ipa_test, args=(results,), kwargs={
                     'provider': self.provider,
                     'access_key_id': creds['access_key_id'],
                     'description': self.description,
                     'distro': self.distro,
-                    'image_id': info['image_id'],
+                    'image_id': self.source_regions[region],
                     'instance_type': self.instance_type,
                     'region': region,
                     'secret_access_key': creds['secret_access_key'],

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -44,6 +44,7 @@ class TestingJob(object):
         self.log_callback = None
         self.provider = self.validate_provider(provider)
         self.status = UNKOWN
+        self.source_regions = None
         self.test_regions = self.validate_test_regions(test_regions)
         self.tests = self.validate_tests(tests)
         self.utctime = self.validate_timestamp(utctime)
@@ -59,14 +60,6 @@ class TestingJob(object):
         Return dictionary of metadata based on job.
         """
         return {'job_id': self.id}
-
-    def get_source_regions(self):
-        """
-        Return a dictionary mapping source regions to image id's.
-        """
-        return {
-            reg: info['image_id'] for reg, info in self.test_regions.items()
-        }
 
     def send_log(self, message, success=True):
         """
@@ -88,20 +81,13 @@ class TestingJob(object):
         """
         self.log_callback = callback
 
-    def test_image(self, host):
+    def test_image(self):
         """
         Get credentials and run image tests with IPA.
         """
         self.iteration_count += 1
         self.send_log('Running IPA tests against image.')
         self._run_tests()
-
-    def update_test_regions(self, source_regions):
-        """
-        Update test_regions dictionary with data from listener message.
-        """
-        for region, image_id in source_regions.items():
-            self.test_regions[region]['image_id'] = image_id
 
     def validate_distro(self, distro):
         """
@@ -154,16 +140,13 @@ class TestingJob(object):
         If format is valid return a dictionary mapping region to
         a dict with account.
         """
-        value = {}
         for region, account in test_regions.items():
-            if region and account:
-                value[region] = {'account': account}
-            else:
+            if not (region and account):
                 raise MashTestingException(
                     'Invalid test_regions format. '
                     'Must be a dict format of {region:account}.'
                 )
-        return value
+        return test_regions
 
     def validate_timestamp(self, utctime):
         """

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -166,7 +166,7 @@ class TestingService(BaseService):
                 'testing_result': {
                     'id': job.id,
                     'cloud_image_name': job.cloud_image_name,
-                    'source_regions': job.get_source_regions(),
+                    'source_regions': job.source_regions,
                     'status': job.status,
                 }
             }
@@ -340,7 +340,7 @@ class TestingService(BaseService):
         Test image with IPA based on job id.
         """
         job = self.jobs[job_id]
-        job.test_image(host=self.host)
+        job.test_image()
 
     def _schedule_job(self, job_id):
         """
@@ -413,7 +413,7 @@ class TestingService(BaseService):
                     )
                     return None
             else:
-                job.update_test_regions(listener_msg['source_regions'])
+                job.source_regions = listener_msg['source_regions']
 
         return job
 

--- a/test/data/empty_testing_config.yml
+++ b/test/data/empty_testing_config.yml
@@ -1,1 +1,0 @@
-testing:

--- a/test/unit/services/testing/config_test.py
+++ b/test/unit/services/testing/config_test.py
@@ -3,10 +3,7 @@ from mash.services.testing.config import TestingConfig
 
 class TestTestingConfig(object):
     def setup(self):
-        self.empty_config = TestingConfig('../data/empty_testing_config.yml')
-
-    def test_config_data(self):
-        assert self.empty_config.config_data
+        self.empty_config = TestingConfig('../data/empty_mash_config.yaml')
 
     def test_get_log_file(self):
         assert self.empty_config.get_log_file('testing') == \

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -48,7 +48,7 @@ class TestEC2TestingJob(object):
                 'ssh_private_key': 'my-key.file'
             }
         }
-        job.update_test_regions({'us-east-1': 'ami-123'})
+        job.source_regions = {'us-east-1': 'ami-123'}
         job._run_tests()
 
         client.describe_key_pairs.assert_called_once_with(

--- a/test/unit/services/testing/job_test.py
+++ b/test/unit/services/testing/job_test.py
@@ -28,13 +28,6 @@ class TestTestingJob(object):
         metadata = job.get_metadata()
         assert metadata == {'job_id': '1'}
 
-    def test_job_get_source_regions(self):
-        job = TestingJob(**self.job_config)
-        job.update_test_regions({'us-east-1': 'ami-123'})
-        source_regions = job.get_source_regions()
-
-        assert source_regions == {'us-east-1': 'ami-123'}
-
     def test_run_tests(self):
         job = TestingJob(**self.job_config)
         with raises(NotImplementedError):
@@ -51,7 +44,7 @@ class TestTestingJob(object):
     def test_test_image(self, mock_run_tests):
         job = TestingJob(**self.job_config)
         job.log_callback = Mock()
-        job.test_image('localhost')
+        job.test_image()
 
         job.log_callback.assert_called_once_with(
             'Pass[1]: Running IPA tests against image.',

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -262,7 +262,7 @@ class TestIPATestingService(object):
         job.status = "success"
         job.cloud_image_name = 'image123'
         job.test_regions = {'us-east-2': {'account': 'test-aws'}}
-        job.get_source_regions.return_value = {'us-east-2': 'ami-123456'}
+        job.source_regions = {'us-east-2': 'ami-123456'}
 
         data = self.testing._get_status_message(job)
         assert data == self.status_message
@@ -385,7 +385,7 @@ class TestIPATestingService(object):
         job.status = "success"
         job.cloud_image_name = 'image123'
         job.test_regions = {'us-east-2': {'account': 'test-aws'}}
-        job.get_source_regions.return_value = {'us-east-2': 'ami-123456'}
+        job.source_regions = {'us-east-2': 'ami-123456'}
 
         self.testing._publish_message(job)
         mock_bind_queue.assert_called_once_with('replication', '1', 'service')
@@ -421,10 +421,9 @@ class TestIPATestingService(object):
         job.image_id = 'image123'
         job.tests = 'test1,test2'
         self.testing.jobs['1'] = job
-        self.testing.host = 'localhost'
 
         self.testing._run_test('1')
-        job.test_image.assert_called_once_with(host='localhost')
+        job.test_image.assert_called_once_with()
 
     def test_testing_schedule_job(self):
         scheduler = Mock()
@@ -545,9 +544,7 @@ class TestIPATestingService(object):
 
         assert result == job
         assert job.cloud_image_name == 'My image'
-        job.update_test_regions.assert_called_once_with(
-            {'us-east-1': 'ami-123456'}
-        )
+        assert job.source_regions == {'us-east-1': 'ami-123456'}
 
     @patch.object(TestingService, '_cleanup_job')
     def test_testing_validate_listener_msg_failed(self, mock_cleanup_job):


### PR DESCRIPTION
- Save source_regions on job instance instead of combining the values with test_regions.
- Remove unused test data yaml file.
- Remove host arg from test method.