### PR TITLE
Use encryption_keys_file instead of private key file.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -1,7 +1,7 @@
 jwt_algorithm: HS256
 jwt_secret: enter-a-secret
 log_dir: /var/log/mash/
-encryption_keys_file: /etc/mash/encryption_keys
+encryption_keys_file: /var/lib/mash/encryption_keys
 services:
   - obs
   - uploader

--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -1,7 +1,7 @@
 jwt_algorithm: HS256
 jwt_secret: enter-a-secret
 log_dir: /var/log/mash/
-private_key_file: /etc/mash/creds_key
+encryption_keys_file: /etc/mash/encryption_keys
 services:
   - obs
   - uploader

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -49,6 +49,17 @@ class BaseConfig(object):
             else:
                 return self.config_data.get(attribute)
 
+    def get_encryption_keys_file(self):
+        """
+        Return the encryption keys file path.
+
+        :rtype: string
+        """
+        encryption_keys_file = self._get_attribute(
+            attribute='encryption_keys_file'
+        )
+        return encryption_keys_file or Defaults.get_encryption_keys_file()
+
     def get_jwt_algorithm(self):
         """
         Return JWT algorithm from MASH config file.
@@ -90,15 +101,6 @@ class BaseConfig(object):
         return '{dir}{service}_service.log'.format(
             dir=log_dir, service=service
         )
-
-    def get_private_key_file(self):
-        """
-        Return the path to the private key file.
-
-        :rtype: string
-        """
-        private_key_file = self._get_attribute(attribute='private_key_file')
-        return private_key_file or Defaults.get_private_key_file()
 
     def get_service_names(self, credentials_required=False):
         """

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -27,6 +27,10 @@ class Defaults(object):
         return '/etc/mash/mash_config.yaml'
 
     @classmethod
+    def get_encryption_keys_file(self):
+        return '/etc/mash/encryption_keys'
+
+    @classmethod
     def get_job_directory(self, service_name):
         return '/var/lib/mash/{0}_jobs/'.format(service_name)
 
@@ -37,10 +41,6 @@ class Defaults(object):
     @classmethod
     def get_log_directory(self):
         return '/var/log/mash/'
-
-    @classmethod
-    def get_private_key_file(self):
-        return '/etc/mash/creds_key'
 
     @classmethod
     def get_service_names(self):

--- a/mash/services/base_defaults.py
+++ b/mash/services/base_defaults.py
@@ -28,7 +28,7 @@ class Defaults(object):
 
     @classmethod
     def get_encryption_keys_file(self):
-        return '/etc/mash/encryption_keys'
+        return '/var/lib/mash/encryption_keys'
 
     @classmethod
     def get_job_directory(self, service_name):

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -1,4 +1,5 @@
 jwt_secret: abc123
+encryption_keys_file: /etc/mash/encryption_keys
 services:
   - obs
   - uploader

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -10,7 +10,7 @@ class TestBaseConfig(object):
 
     def test_get_encryption_keys_file(self):
         enc_keys_file = self.empty_config.get_encryption_keys_file()
-        assert enc_keys_file == '/etc/mash/encryption_keys'
+        assert enc_keys_file == '/var/lib/mash/encryption_keys'
 
     def test_get_jwt_algorithm(self):
         algorithm = self.empty_config.get_jwt_algorithm()

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -8,6 +8,10 @@ class TestBaseConfig(object):
         self.empty_config = BaseConfig('../data/empty_mash_config.yaml')
         self.config = BaseConfig('../data/mash_config.yaml')
 
+    def test_get_encryption_keys_file(self):
+        enc_keys_file = self.empty_config.get_encryption_keys_file()
+        assert enc_keys_file == '/etc/mash/encryption_keys'
+
     def test_get_jwt_algorithm(self):
         algorithm = self.empty_config.get_jwt_algorithm()
         assert algorithm == 'HS256'
@@ -22,9 +26,6 @@ class TestBaseConfig(object):
             self.empty_config.get_jwt_secret()
 
         assert msg == str(error.value)
-
-    def test_get_private_key_file(self):
-        assert self.config.get_private_key_file() == '/etc/mash/creds_key'
 
     def test_get_services_names(self):
         expected = {


### PR DESCRIPTION
- With symmetric key encryption no need for public and private keys.
- File will contain a list of encryption keys (initially just one) that will eventually be used in key rotation.