### PR TITLE
Attempt to remove scheduler job only on cleanup.

### DIFF
--- a/mash/services/publisher/service.py
+++ b/mash/services/publisher/service.py
@@ -84,6 +84,13 @@ class PublisherService(BaseService):
         job.status = status
         self.log.warning('Failed upstream.', extra=job.get_metadata())
 
+        try:
+            # Remove job from scheduler if it has
+            # not started executing yet.
+            self.scheduler.remove_job(job.id)
+        except JobLookupError:
+            pass
+
         self._delete_job(job.id)
         self._publish_message(job)
 
@@ -124,13 +131,6 @@ class PublisherService(BaseService):
         Remove job from dict and delete listener queue.
         """
         if job_id in self.jobs:
-            try:
-                # Remove job from scheduler if it has
-                # not started executing yet.
-                self.scheduler.remove_job(job_id)
-            except JobLookupError:
-                pass
-
             job = self.jobs[job_id]
             self.log.info(
                 'Deleting job.',

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -92,6 +92,13 @@ class TestingService(BaseService):
         job.status = status
         self.log.warning('Failed upstream.', extra=job.get_metadata())
 
+        try:
+            # Remove job from scheduler if it has
+            # not started executing yet.
+            self.scheduler.remove_job(job.id)
+        except JobLookupError:
+            pass
+
         self._delete_job(job.id)
         self._publish_message(job)
 
@@ -133,13 +140,6 @@ class TestingService(BaseService):
         Remove job from dict and delete listener queue.
         """
         if job_id in self.jobs:
-            try:
-                # Remove job from scheduler if it has
-                # not started executing yet.
-                self.scheduler.remove_job(job_id)
-            except JobLookupError:
-                pass
-
             job = self.jobs[job_id]
             self.log.info(
                 'Deleting job.',

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -147,10 +147,6 @@ class TestIPATestingService(object):
         job.id = '1'
         job.get_metadata.return_value = {'job_id': '1'}
 
-        scheduler = Mock()
-        scheduler.remove_job.side_effect = JobLookupError('1')
-
-        self.testing.scheduler = scheduler
         self.testing.jobs['1'] = job
         self.testing._delete_job('1')
 
@@ -158,7 +154,6 @@ class TestIPATestingService(object):
             'Deleting job.',
             extra={'job_id': '1'}
         )
-        scheduler.remove_job.assert_called_once_with('1')
         mock_unbind_queue.assert_called_once_with(
             'listener', 'testing', '1'
         )
@@ -173,6 +168,10 @@ class TestIPATestingService(object):
         job.utctime = 'now'
         job.get_metadata.return_value = {'job_id': '1'}
 
+        scheduler = Mock()
+        scheduler.remove_job.side_effect = JobLookupError('1')
+        self.testing.scheduler = scheduler
+
         self.testing.jobs['1'] = job
         self.testing._cleanup_job(job, 1)
 
@@ -180,6 +179,7 @@ class TestIPATestingService(object):
             'Failed upstream.',
             extra={'job_id': '1'}
         )
+        scheduler.remove_job.assert_called_once_with('1')
         mock_delete_job.assert_called_once_with('1')
         mock_publish_message.assert_called_once_with(job)
 


### PR DESCRIPTION
Move from delete_job method. If scheduler callback is called the job is marked for deletion. Thus remove_job is called twice randomly throwing exception if the second occurrence happens in the scheduler.