### PR TITLE
Remove source region from results after replication

### DIFF
--- a/examples/messages/deprecation_result.json
+++ b/examples/messages/deprecation_result.json
@@ -2,12 +2,6 @@
     "deprecation_result": {
         "id": "123",
         "cloud_image_name": "image_123",
-        "source_regions": {
-            "us-east-2": "ami-bc5b48d0",
-            "us-west-2": "ami-bc5b48d0",
-            "eu-west-2": "ami-bc5b48d0",
-            "cn-northwest-1": "ami-bc5b4853"
-        },
         "status": "success"
     }
 }

--- a/examples/messages/publisher_result.json
+++ b/examples/messages/publisher_result.json
@@ -2,12 +2,6 @@
     "publisher_result": {
         "id": "123",
         "cloud_image_name": "image_123",
-        "source_regions": {
-            "us-east-2": "ami-bc5b48d0",
-            "us-west-2": "ami-bc5b48d0",
-            "eu-west-2": "ami-bc5b48d0",
-            "cn-northwest-1": "ami-bc5b4853"
-        },
         "status": "success"
     }
 }

--- a/examples/messages/replication_result.json
+++ b/examples/messages/replication_result.json
@@ -2,12 +2,6 @@
     "replication_result": {
         "id": "123",
         "cloud_image_name": "image_123",
-        "source_regions": {
-            "us-east-2": "ami-bc5b48d0",
-            "us-west-2": "ami-bc5b48d0",
-            "eu-west-2": "ami-bc5b48d0",
-            "cn-northwest-1": "ami-bc5b4853"
-        },
         "status": "success"
     }
 }

--- a/mash/services/publisher/ec2_job.py
+++ b/mash/services/publisher/ec2_job.py
@@ -51,6 +51,7 @@ class EC2PublisherJob(PublisherJob):
             publisher = EC2PublishImage(
                 access_key=creds['access_key_id'],
                 allow_copy=self.allow_copy,
+                image_name=self.cloud_image_name,
                 secret_key=creds['secret_access_key'],
                 verbose=False,
                 visibility=self.share_with,
@@ -58,13 +59,12 @@ class EC2PublisherJob(PublisherJob):
 
             for region in region_info['target_regions']:
                 publisher.set_region(region)
-                publisher.image_id = self.source_regions[region]
                 try:
                     publisher.publish_images()
                 except Exception as error:
                     raise MashPublisherException(
                         'An error publishing image {0} in {1}. {2}'.format(
-                            self.source_regions[region], region, error
+                            self.cloud_image_name, region, error
                         )
                     )
 

--- a/mash/services/publisher/job.py
+++ b/mash/services/publisher/job.py
@@ -37,7 +37,6 @@ class PublisherJob(object):
         self.log_callback = None
         self.provider = self.validate_provider(provider)
         self.publish_regions = self.validate_publish_regions(publish_regions)
-        self.source_regions = None
         self.status = UNKOWN
         self.utctime = self.validate_timestamp(utctime)
 

--- a/mash/services/publisher/service.py
+++ b/mash/services/publisher/service.py
@@ -159,7 +159,6 @@ class PublisherService(BaseService):
                 'publisher_result': {
                     'id': job.id,
                     'cloud_image_name': job.cloud_image_name,
-                    'source_regions': job.source_regions,
                     'status': job.status,
                 }
             }
@@ -194,13 +193,7 @@ class PublisherService(BaseService):
             "replication_result": {
                 "id": "123",
                 "cloud_image_name": "image_123",
-                "source_regions": {
-                    "us-east-2": "ami-bc5b48d0",
-                    "us-west-2": "ami-bc5b48d0",
-                    "eu-west-2": "ami-bc5b48d0",
-                    "cn-northwest-1": "ami-bc5b4853"
-                },
-                "status": "success",
+                "status": "success"
             }
         }
 
@@ -398,14 +391,13 @@ class PublisherService(BaseService):
             self._cleanup_job(job, status)
             return None
         else:
-            for attr in ['cloud_image_name', 'source_regions']:
-                if attr not in listener_msg:
-                    self.log.error(
-                        '{0} is required in replication result.'.format(attr)
-                    )
-                    return None
-                else:
-                    setattr(job, attr, listener_msg[attr])
+            if 'cloud_image_name' not in listener_msg:
+                self.log.error(
+                    'cloud_image_name is required in replication result.'
+                )
+                return None
+            else:
+                job.cloud_image_name = listener_msg['cloud_image_name']
 
         return job
 

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -139,17 +139,6 @@ class EC2ReplicationJob(ReplicationJob):
             )
             self.status = FAILED
 
-    def get_source_regions_result(self):
-        """
-        Return a dictionary mapping source regions to image ids.
-        """
-        result_regions = {
-            region: info['image_id'] for region, info
-            in self.source_region_results.items()
-        }
-        result_regions.update(self.source_regions)
-        return result_regions
-
     def image_exists(self, client, cloud_image_name):
         """
         Determine if image exists given image name.

--- a/mash/services/replication/ec2_job.py
+++ b/mash/services/replication/ec2_job.py
@@ -43,7 +43,7 @@ class EC2ReplicationJob(ReplicationJob):
         self.cloud_image_name = cloud_image_name
         self.job_file = job_file
         self.source_region_results = defaultdict(dict)
-        self.source_regions = None
+        self.source_regions = {}
         self.replication_source_regions = \
             self.validate_replication_source_regions(
                 replication_source_regions
@@ -143,10 +143,12 @@ class EC2ReplicationJob(ReplicationJob):
         """
         Return a dictionary mapping source regions to image ids.
         """
-        return {
+        result_regions = {
             region: info['image_id'] for region, info
             in self.source_region_results.items()
         }
+        result_regions.update(self.source_regions)
+        return result_regions
 
     def image_exists(self, client, cloud_image_name):
         """

--- a/mash/services/replication/service.py
+++ b/mash/services/replication/service.py
@@ -160,7 +160,6 @@ class ReplicationService(BaseService):
                 'replication_result': {
                     'id': job.id,
                     'cloud_image_name': job.cloud_image_name,
-                    'source_regions': job.get_source_regions_result(),
                     'status': job.status,
                 }
             }
@@ -381,15 +380,13 @@ class ReplicationService(BaseService):
             self._cleanup_job(job, status)
             return None
         else:
-            # Required args
-            for attr in ['cloud_image_name', 'source_regions']:
-                if attr not in listener_msg:
-                    self.log.error(
-                        '{0} is required in testing result.'.format(attr)
-                    )
-                    return None
-                else:
-                    setattr(job, attr, listener_msg[attr])
+            if 'cloud_image_name' not in listener_msg:
+                self.log.error(
+                    'cloud_image_name is required in testing result.'
+                )
+                return None
+            else:
+                job.cloud_image_name = listener_msg['cloud_image_name']
 
         return job
 

--- a/test/unit/services/publisher/ec2_job_test.py
+++ b/test/unit/services/publisher/ec2_job_test.py
@@ -36,12 +36,11 @@ class TestEC2PublisherJob(object):
     def test_publish(self, mock_ec2_publish_image):
         publisher = Mock()
         mock_ec2_publish_image.return_value = publisher
-
-        self.job.source_regions = {'us-east-2': 'ami-123456'}
+        self.job.cloud_image_name = 'image_name_123'
         self.job._publish()
 
         mock_ec2_publish_image.assert_called_once_with(
-            access_key='123456', allow_copy=False,
+            access_key='123456', allow_copy=False, image_name='image_name_123',
             secret_key='654321', verbose=False, visibility='all'
         )
 
@@ -59,9 +58,9 @@ class TestEC2PublisherJob(object):
         publisher.publish_images.side_effect = Exception('Failed to publish.')
         mock_ec2_publish_image.return_value = publisher
 
-        self.job.source_regions = {'us-east-2': 'ami-123456'}
+        self.job.cloud_image_name = 'image_name_123'
 
-        msg = 'An error publishing image ami-123456 in us-east-2.' \
+        msg = 'An error publishing image image_name_123 in us-east-2.' \
             ' Failed to publish.'
         with raises(MashPublisherException) as e:
             self.job._publish()

--- a/test/unit/services/publisher/service_test.py
+++ b/test/unit/services/publisher/service_test.py
@@ -37,7 +37,6 @@ class TestPublisherService(object):
             '{"id": "1", "status": "error"}}'
         self.status_message = '{"publisher_result": ' \
             '{"cloud_image_name": "image123", "id": "1", ' \
-            '"source_regions": {"us-east-1": "ami-12345"}, ' \
             '"status": "success"}}'
 
         self.publisher = PublisherService()
@@ -217,7 +216,6 @@ class TestPublisherService(object):
         job.id = '1'
         job.status = 'success'
         job.cloud_image_name = 'image123'
-        job.source_regions = {'us-east-1': 'ami-12345'}
 
         data = self.publisher._get_status_message(job)
         assert data == self.status_message
@@ -255,7 +253,6 @@ class TestPublisherService(object):
         self.message.body = \
             '{"replication_result": {"id": "1", ' \
             '"cloud_image_name": "image name", ' \
-            '"source_regions": {"us-west-1": "ami-123456"}, ' \
             '"status": "success"}}'
 
         self.publisher._handle_listener_message(self.message)
@@ -277,7 +274,6 @@ class TestPublisherService(object):
         self.message.body = \
             '{"replication_result": {"id": "1", ' \
             '"cloud_image_name": "image name", ' \
-            '"source_regions": {"us-west-1": "ami-123456"}, ' \
             '"status": "success"}}'
 
         self.publisher._handle_listener_message(self.message)
@@ -292,9 +288,7 @@ class TestPublisherService(object):
         self.publisher.jobs['1'] = job
 
         self.message.body = \
-            '{"replication_result": {"id": "1", ' \
-            '"cloud_image_name": "image name", ' \
-            '"source_regions": {"us-west-1": "ami-123"}, "status": "error"}}'
+            '{"replication_result": {"id": "1", "status": "error"}}'
         self.publisher._handle_listener_message(self.message)
 
         mock_cleanup_job.assert_called_once_with(job, 'error')
@@ -302,9 +296,7 @@ class TestPublisherService(object):
 
     def test_publisher_listener_message_job_none(self):
         self.message.body = \
-            '{"replication_result": {"id": "1", ' \
-            '"cloud_image_name": "image name", ' \
-            '"source_regions": {"us-west-1": "ami-123"}, "status": "error"}}'
+            '{"replication_result": {"id": "1", "status": "error"}}'
         self.publisher._handle_listener_message(self.message)
 
         self.message.ack.assert_called_once_with()
@@ -474,7 +466,6 @@ class TestPublisherService(object):
         job.id = '1'
         job.status = 'success'
         job.cloud_image_name = 'image123'
-        job.source_regions = {'us-east-1': 'ami-12345'}
 
         self.publisher._publish_message(job)
         mock_publish.assert_called_once_with(

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -146,20 +146,6 @@ class TestEC2ReplicationJob(object):
         )
         assert self.job.status == FAILED
 
-    def test_replicate_get_source_regions_result(self):
-        self.job.source_region_results = {
-            'us-east-2': {
-                'image_id': 'ami-54321',
-                'account': Mock()
-            }
-        }
-        self.job.source_regions = {'us-west-1': 'ami-12345'}
-
-        result = self.job.get_source_regions_result()
-
-        assert result['us-east-2'] == 'ami-54321'
-        assert result['us-west-1'] == 'ami-12345'
-
     def test_replicate_image_exists(self):
         images = {'Images': []}
         client = Mock()

--- a/test/unit/services/replication/ec2_job_test.py
+++ b/test/unit/services/replication/ec2_job_test.py
@@ -153,10 +153,12 @@ class TestEC2ReplicationJob(object):
                 'account': Mock()
             }
         }
+        self.job.source_regions = {'us-west-1': 'ami-12345'}
 
         result = self.job.get_source_regions_result()
 
         assert result['us-east-2'] == 'ami-54321'
+        assert result['us-west-1'] == 'ami-12345'
 
     def test_replicate_image_exists(self):
         images = {'Images': []}

--- a/test/unit/services/replication/service_test.py
+++ b/test/unit/services/replication/service_test.py
@@ -38,7 +38,6 @@ class TestReplicationService(object):
             '{"id": "1", "status": "error"}}'
         self.status_message = '{"replication_result": ' \
             '{"cloud_image_name": "image123", "id": "1", ' \
-            '"source_regions": {"us-east-1": "ami-12345"}, ' \
             '"status": "success"}}'
 
         self.replication = ReplicationService()
@@ -221,7 +220,6 @@ class TestReplicationService(object):
         job.id = '1'
         job.status = 'success'
         job.cloud_image_name = 'image123'
-        job.get_source_regions_result.return_value = {'us-east-1': 'ami-12345'}
 
         data = self.replication._get_status_message(job)
         assert data == self.status_message
@@ -496,7 +494,6 @@ class TestReplicationService(object):
         job.id = '1'
         job.status = 'success'
         job.cloud_image_name = 'image123'
-        job.get_source_regions_result.return_value = {'us-east-1': 'ami-12345'}
 
         self.replication._publish_message(job)
         mock_publish.assert_called_once_with(


### PR DESCRIPTION
No need to pass source regions after replication. Publishing, deprecation and PINT service use image name.