### PR TITLE
Job initiation message received by job creator.

### DIFF
--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -1,0 +1,25 @@
+{
+  "provider": "ec2",
+  "provider_accounts": ["test-aws"],
+  "requesting_user": "user1",
+  "last_service": "testing",
+  "utctime": "now",
+  "image": "test_image_oem",
+  "cloud_image_name": "new_image_123",
+  "old_cloud_image_name": "old_new_image_123",
+  "project": "Cloud:Tools",
+  "conditions": [
+    {"package": ["name", "and", "constraints"]},
+    {"image": "version"}
+  ],
+  "share_with": "all",
+  "allow_copy": "",
+  "image_description": "New Image #123",
+  "target_regions": {
+    "accounts": {
+      "test-aws": []
+    },
+    "groups": []
+  },
+  "tests": ["test_stuff"]
+}


### PR DESCRIPTION
Any subset of groups and accounts can be supplied. For accounts a list of target regions can be provided to override the default list of all available regions.