### PR TITLE
Return consistent collections type.

### DIFF
--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -114,6 +114,7 @@ class BaseConfig(object):
             non_cred_services = self._get_attribute(
                 attribute='non_cred_services'
             ) or Defaults.get_non_credential_service_names()
-            services = set(services) - set(non_cred_services)
+            services = [service for service in services
+                        if service not in non_cred_services]
 
         return services

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -27,7 +27,7 @@ class TestBaseConfig(object):
         assert self.config.get_private_key_file() == '/etc/mash/creds_key'
 
     def test_get_services_names(self):
-        # Non credential services
+        # Services requiring credentials
         expected = [
             'uploader', 'testing', 'replication', 'publisher',
             'deprecation', 'pint'

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -27,11 +27,17 @@ class TestBaseConfig(object):
         assert self.config.get_private_key_file() == '/etc/mash/creds_key'
 
     def test_get_services_names(self):
-        expected = {
-            'publisher', 'pint', 'testing', 'replication',
-            'uploader', 'deprecation'
-        }
+        # Non credential services
+        expected = [
+            'uploader', 'testing', 'replication', 'publisher',
+            'deprecation', 'pint'
+        ]
         services = self.empty_config.get_service_names(
             credentials_required=True
         )
-        assert not (expected - services)
+        assert expected == services
+
+        # All services
+        expected = ['obs'] + expected
+        services = self.empty_config.get_service_names()
+        assert expected == services


### PR DESCRIPTION
In base config get services list. Don't use sets to preserve order of services when returning non credential services.