### PR TITLE
Use temp ssh keys in testing service.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -17,4 +17,4 @@ credentials:
 obs:
   download_directory: /var/tmp/mash/images
 testing:
-  ssh_private_key_file: /etc/mash/testing_key
+  ssh_private_key_file: /etc/mash/key

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -32,7 +32,7 @@ class EC2TestingJob(TestingJob):
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
         job_file=None, credentials=None, description=None, distro=None,
-        instance_type=None, ssh_user='ec2-user'
+        instance_type='t2.micro', ssh_user='ec2-user'
     ):
         super(EC2TestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
@@ -59,7 +59,7 @@ class EC2TestingJob(TestingJob):
                     'instance_type': self.instance_type,
                     'region': region,
                     'secret_access_key': creds['secret_access_key'],
-                    'ssh_private_key': self.ssh_private_key_file,
+                    'ssh_private_key_file': self.ssh_private_key_file,
                     'ssh_user': self.ssh_user,
                     'tests': self.tests
                 }

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -95,7 +95,7 @@ class TestingJob(object):
         Validate the distro is supported for testing.
         """
         if not distro:
-            distro = 'SLES'
+            distro = 'sles'
         elif distro not in ('openSUSE_Leap', 'SLES'):
             raise MashTestingException(
                 'Distro: {0} not supported.'.format(distro)

--- a/mash/utils/generic.py
+++ b/mash/utils/generic.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import random
+from string import ascii_lowercase
+
+
+def generate_name(length=8):
+    """
+    Generate a random lowercase string of the given length: Default of 8.
+    """
+    return ''.join([random.choice(ascii_lowercase) for i in range(length)])
+
+
+def get_key_from_file(key_file_path):
+    """
+    Return a key as string from the given file.
+    """
+    with open(key_file_path, 'r') as key_file:
+        key = key_file.read().strip()
+
+    return key

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, patch
+from unittest.mock import call, Mock, patch
 
 from mash.services.testing.ec2_job import EC2TestingJob
 
@@ -14,11 +14,20 @@ class TestEC2TestingJob(object):
             'utctime': 'now',
         }
 
+    @patch('mash.services.testing.ipa_helper.generate_name')
+    @patch('mash.services.testing.ipa_helper.get_client')
+    @patch('mash.services.testing.ipa_helper.get_key_from_file')
     @patch('mash.services.testing.ipa_helper.test_image')
     @patch.object(EC2TestingJob, 'send_log')
     def test_testing_run_test(
-        self, mock_send_log, mock_test_image
+        self, mock_send_log, mock_test_image, mock_get_key_from_file,
+        mock_get_client, mock_generate_name
     ):
+        client = Mock()
+        mock_get_client.return_value = client
+        mock_generate_name.return_value = 'random_name'
+        mock_get_key_from_file.return_value = 'fakekey'
+
         mock_test_image.return_value = (
             0,
             {
@@ -41,21 +50,26 @@ class TestEC2TestingJob(object):
         job.source_regions = {'us-east-1': 'ami-123'}
         job._run_tests()
 
+        client.import_key_pair.assert_called_once_with(
+            KeyName='random_name', PublicKeyMaterial='fakekey'
+        )
         mock_test_image.assert_called_once_with(
-            'EC2',
-            cleanup=True,
+            'ec2',
             access_key_id='123',
+            cleanup=True,
             desc=job.description,
-            distro='SLES',
+            distro='sles',
             image_id='ami-123',
-            instance_type=job.instance_type,
+            instance_type='t2.micro',
             log_level=30,
             region='us-east-1',
             secret_access_key='321',
+            ssh_key_name='random_name',
             ssh_private_key='private_ssh_key.file',
             ssh_user='ec2-user',
             tests=['test_stuff']
         )
+        client.delete_key_pair.assert_called_once_with(KeyName='random_name')
 
         # Failed job test
         mock_test_image.side_effect = Exception('Tests broken!')
@@ -64,3 +78,7 @@ class TestEC2TestingJob(object):
             [call('Image tests failed in region: us-east-1.', success=False),
              call('Tests broken!', success=False)]
         )
+
+        # Failed key cleanup
+        client.delete_key_pair.side_effect = Exception('Cannot delete key!')
+        job._run_tests()

--- a/test/unit/utils/generic_test.py
+++ b/test/unit/utils/generic_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import io
+
+from unittest.mock import MagicMock, patch
+from mash.utils.generic import generate_name, get_key_from_file
+
+
+def test_generate_name():
+    result = generate_name(10)
+    assert len(result) == 10
+
+
+def test_get_key_from_file():
+    with patch('builtins.open', create=True) as mock_open:
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.read.return_value = 'fakekey'
+        result = get_key_from_file('my-key.file')
+
+    assert result == 'fakekey'


### PR DESCRIPTION
Key is created based on the supplied private key file prior to testing in the testing account. After testing the key is removed.