### PR TITLE
Remove validation From Testing Job Class

### DIFF
--- a/examples/messages/testing_job.json
+++ b/examples/messages/testing_job.json
@@ -2,7 +2,7 @@
     "testing_job": {
         "id": "123",
         "provider": "ec2",
-        "tests": "test_stuff",
+        "tests": ["test_stuff"],
         "utctime": "now",
         "test_regions": {
             "us-east-1": "test-aws",

--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -31,7 +31,7 @@ class EC2TestingJob(TestingJob):
 
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
-        job_file=None, credentials=None, description=None, distro=None,
+        job_file=None, credentials=None, description=None, distro='sles',
         instance_type=None, ssh_user='ec2-user'
     ):
         super(EC2TestingJob, self).__init__(

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -10,7 +10,7 @@ class TestEC2TestingJob(object):
             'provider': 'ec2',
             'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'us-east-1': 'test-aws'},
-            'tests': 'test_stuff',
+            'tests': ['test_stuff'],
             'utctime': 'now',
         }
 
@@ -46,7 +46,7 @@ class TestEC2TestingJob(object):
             cleanup=True,
             access_key_id='123',
             desc=job.description,
-            distro='SLES',
+            distro='sles',
             image_id='ami-123',
             instance_type=job.instance_type,
             log_level=30,

--- a/test/unit/services/testing/job_test.py
+++ b/test/unit/services/testing/job_test.py
@@ -12,7 +12,7 @@ class TestTestingJob(object):
             'provider': 'ec2',
             'ssh_private_key_file': 'private_ssh_key.file',
             'test_regions': {'us-east-1': 'test-aws'},
-            'tests': 'test_stuff',
+            'tests': ['test_stuff'],
             'utctime': 'now'
         }
 
@@ -53,49 +53,10 @@ class TestTestingJob(object):
             True
         )
 
-    def test_invalid_distro(self):
-        self.job_config['distro'] = 'Fake'
-        msg = 'Distro: Fake not supported.'
-        with raises(MashTestingException) as e:
-            TestingJob(**self.job_config)
-
-        assert str(e.value) == msg
-
-    def test_invalid_provider(self):
-        self.job_config['provider'] = 'Fake'
-        msg = 'Provider: Fake not supported.'
-        with raises(MashTestingException) as e:
-            TestingJob(**self.job_config)
-
-        assert str(e.value) == msg
-
-    def test_invalid_tests(self):
-        self.job_config['tests'] = ''
-        msg = 'Must provide at least one test.'
-        with raises(MashTestingException) as e:
-            TestingJob(**self.job_config)
-
-        assert str(e.value) == msg
-
-        self.job_config['tests'] = ['test_stuff']
-        msg = 'Invalid tests format, must be a comma seperated list.'
-        with raises(MashTestingException) as e:
-            TestingJob(**self.job_config)
-
-        assert str(e.value) == msg
-
     def test_invalid_test_regions(self):
         self.job_config['test_regions'] = {'us-east-1': None}
         msg = 'Invalid test_regions format. ' \
             'Must be a dict format of {region:account}.'
-        with raises(MashTestingException) as e:
-            TestingJob(**self.job_config)
-
-        assert str(e.value) == msg
-
-    def test_invalid_timestamp(self):
-        self.job_config['utctime'] = 'never'
-        msg = 'Invalid utctime format: never.'
         with raises(MashTestingException) as e:
             TestingJob(**self.job_config)
 


### PR DESCRIPTION
- Params will be validated by job creator before sending out job documents.
- Tests will be a list instead of comma separated string.
- Move distro default 'sles' to init method.