### PR TITLE
Attempt creating log dir if it does not exist.

### DIFF
--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -361,6 +361,10 @@ class BaseService(object):
         Allow to set a custom service log file
         """
         try:
+            log_dir = os.path.dirname(logfile)
+            if not os.path.isdir(log_dir):
+                os.makedirs(log_dir)
+
             logfile_handler = logging.FileHandler(
                 filename=logfile, encoding='utf-8'
             )

--- a/test/unit/services/base/service_test.py
+++ b/test/unit/services/base/service_test.py
@@ -52,12 +52,21 @@ class TestBaseService(object):
     def test_post_init(self):
         self.service.post_init()
 
+    @patch('mash.services.base_service.os')
     @patch('logging.FileHandler')
-    def test_set_logfile(self, mock_logging_FileHandler):
+    def test_set_logfile(self, mock_logging_FileHandler, mock_os):
         logfile_handler = Mock()
         mock_logging_FileHandler.return_value = logfile_handler
 
+        mock_os.path.dirname.return_value = '/some'
+        mock_os.path.isdir.return_value = False
+
         self.service.set_logfile('/some/log')
+
+        mock_os.path.dirname.assert_called_with('/some/log')
+        mock_os.path.isdir.assert_called_with('/some')
+        mock_os.makedirs.assert_called_with('/some')
+
         mock_logging_FileHandler.assert_called_once_with(
             encoding='utf-8', filename='/some/log'
         )
@@ -65,8 +74,9 @@ class TestBaseService(object):
             [call(logfile_handler)]
         )
 
+    @patch('mash.services.base_service.os')
     @patch('logging.FileHandler')
-    def test_set_logfile_raises(self, mock_logging_FileHandler):
+    def test_set_logfile_raises(self, mock_logging_FileHandler, mock_os):
         mock_logging_FileHandler.side_effect = Exception
         with raises(MashLogSetupException):
             self.service.set_logfile('/some/log')


### PR DESCRIPTION
When setting log handler. File handler can create the file if it does not exist but not the directory.

Resolves #183 