### PR TITLE
Move ssh private key file to base config.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -2,6 +2,7 @@ jwt_algorithm: HS256
 jwt_secret: enter-a-secret
 log_dir: /var/log/mash/
 encryption_keys_file: /var/lib/mash/encryption_keys
+ssh_private_key_file: /var/lib/mash/ssh_key
 services:
   - obs
   - uploader
@@ -18,5 +19,3 @@ jobcreator:
   accounts_file: /etc/mash/accounts.json
 obs:
   download_directory: /var/tmp/mash/images
-testing:
-  ssh_private_key_file: /etc/mash/testing_key

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -120,3 +120,20 @@ class BaseConfig(object):
                         if service not in non_cred_services]
 
         return services
+
+    def get_ssh_private_key_file(self):
+        """
+        Return the path to the ssh private key file.
+
+        :rtype: string
+        """
+        private_key_file = self._get_attribute(
+            attribute='ssh_private_key_file'
+        )
+
+        if not private_key_file:
+            raise MashConfigException(
+                'ssh_private_key_file is required in MASH configuration file.'
+            )
+
+        return private_key_file

--- a/mash/services/testing/config.py
+++ b/mash/services/testing/config.py
@@ -16,7 +16,6 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
-from mash.mash_exceptions import MashConfigException
 from mash.services.base_config import BaseConfig
 
 
@@ -33,21 +32,3 @@ class TestingConfig(BaseConfig):
 
     def __init__(self, config_file=None):
         super(TestingConfig, self).__init__(config_file)
-
-    def get_ssh_private_key_file(self):
-        """
-        Return the path to the ssh private key file.
-
-        :rtype: string
-        """
-        private_key_file = self._get_attribute(
-            attribute='ssh_private_key_file', element='testing'
-        )
-
-        if not private_key_file:
-            raise MashConfigException(
-                'ssh_private_key_file is required in configuration file for '
-                'testing service.'
-            )
-
-        return private_key_file

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -1,5 +1,6 @@
 jwt_secret: abc123
 encryption_keys_file: /etc/mash/encryption_keys
+ssh_private_key_file: /var/lib/mash/ssh_key
 services:
   - obs
   - uploader
@@ -10,5 +11,3 @@ services:
   - pint
 non_cred_services:
   - obs
-testing:
-  ssh_private_key_file: /etc/mash/testing_key

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -42,3 +42,13 @@ class TestBaseConfig(object):
         expected = ['obs'] + expected
         services = self.empty_config.get_service_names()
         assert expected == services
+
+    def test_get_ssh_private_key_file(self):
+        assert self.config.get_ssh_private_key_file() == \
+            '/var/lib/mash/ssh_key'
+
+        with raises(MashConfigException) as error:
+            self.empty_config.get_ssh_private_key_file()
+
+        assert str(error.value) == \
+            'ssh_private_key_file is required in MASH configuration file.'

--- a/test/unit/services/testing/config_test.py
+++ b/test/unit/services/testing/config_test.py
@@ -1,6 +1,3 @@
-from pytest import raises
-
-from mash.mash_exceptions import MashConfigException
 from mash.services.testing.config import TestingConfig
 
 
@@ -12,12 +9,3 @@ class TestTestingConfig(object):
     def test_get_log_file(self):
         assert self.empty_config.get_log_file('testing') == \
             '/var/log/mash/testing_service.log'
-
-    def test_get_ssh_private_key_file(self):
-        assert self.config.get_ssh_private_key_file() == \
-            '/etc/mash/testing_key'
-
-        with raises(MashConfigException) as error:
-            self.empty_config.get_ssh_private_key_file()
-
-        assert str(error.value)


### PR DESCRIPTION
Used by both uploader and testing services.

@schaefi This moves the ssh key in config to base so both services can share the value.

In #164 I added generic utility methods for creating random name and getting the public key from file.