### PR TITLE
Update job doc example.

### DIFF
--- a/examples/messages/job.json
+++ b/examples/messages/job.json
@@ -1,8 +1,11 @@
 {
   "provider": "ec2",
-  "provider_accounts": ["test-aws"],
+  "provider_accounts": {
+    "test-aws-gov": ["us-gov-west-1"]
+  },
+  "provider_groups": ["test"],
   "requesting_user": "user1",
-  "last_service": "testing",
+  "last_service": "pint",
   "utctime": "now",
   "image": "test_image_oem",
   "cloud_image_name": "new_image_123",
@@ -13,13 +16,7 @@
     {"image": "version"}
   ],
   "share_with": "all",
-  "allow_copy": "",
+  "allow_copy": false,
   "image_description": "New Image #123",
-  "target_regions": {
-    "accounts": {
-      "test-aws": []
-    },
-    "groups": []
-  },
   "tests": ["test_stuff"]
 }


### PR DESCRIPTION
- Target regions doesn't make sense and causes duplication of data.
- User can supply a list of groups and a list of accounts.

For accounts a list of target regions can be provided which
overrides the defaults for that accounts' partition.