### PR TITLE
Rename ipa_helper to ec2_ipa_helper.

### DIFF
--- a/mash/services/testing/ec2_job.py
+++ b/mash/services/testing/ec2_job.py
@@ -19,7 +19,7 @@
 from threading import Thread
 
 from mash.services.status_levels import FAILED, SUCCESS
-from mash.services.testing.ipa_helper import ipa_test
+from mash.services.testing.ec2_ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 
@@ -37,7 +37,7 @@ class EC2TestingJob(TestingJob):
         super(EC2TestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,
-            instance_type=instance_type
+            instance_type=instance_type, ssh_user=ssh_user
         )
         self.ssh_user = ssh_user
 

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -29,7 +29,8 @@ class TestingJob(object):
 
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
-        job_file=None, description=None, distro='sles', instance_type=None
+        job_file=None, description=None, distro='sles', instance_type=None,
+        ssh_user=None
     ):
         self.cloud_image_name = None
         self.job_file = job_file
@@ -44,6 +45,7 @@ class TestingJob(object):
         self.status = UNKOWN
         self.source_regions = None
         self.ssh_private_key_file = ssh_private_key_file
+        self.ssh_user = ssh_user
         self.test_regions = self.validate_test_regions(test_regions)
         self.tests = tests
         self.utctime = utctime

--- a/mash/utils/ec2.py
+++ b/mash/utils/ec2.py
@@ -18,6 +18,10 @@
 
 import boto3
 
+from contextlib import contextmanager, suppress
+
+from mash.utils.mash_utils import generate_name, get_key_from_file
+
 
 def get_client(service_name, access_key_id, secret_access_key, region_name):
     """
@@ -29,3 +33,27 @@ def get_client(service_name, access_key_id, secret_access_key, region_name):
         aws_secret_access_key=secret_access_key,
         region_name=region_name,
     )
+
+
+@contextmanager
+def temp_key_pair(
+    access_key_id, region, secret_access_key, ssh_private_key_file
+):
+    """
+    Create a temp key pair in the account and region.
+
+    Return the key pair name.
+    """
+    try:
+        key_name = generate_name()
+        client = get_client(
+            'ec2', access_key_id, secret_access_key, region
+        )
+        ssh_public_key = get_key_from_file(ssh_private_key_file + '.pub')
+        client.import_key_pair(
+            KeyName=key_name, PublicKeyMaterial=ssh_public_key
+        )
+        yield key_name
+    finally:
+        with suppress(Exception):
+            client.delete_key_pair(KeyName=key_name)

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -14,10 +14,10 @@ class TestEC2TestingJob(object):
             'utctime': 'now',
         }
 
-    @patch('mash.services.testing.ipa_helper.generate_name')
-    @patch('mash.services.testing.ipa_helper.get_client')
-    @patch('mash.services.testing.ipa_helper.get_key_from_file')
-    @patch('mash.services.testing.ipa_helper.test_image')
+    @patch('mash.utils.ec2.generate_name')
+    @patch('mash.utils.ec2.get_client')
+    @patch('mash.utils.ec2.get_key_from_file')
+    @patch('mash.services.testing.ec2_ipa_helper.test_image')
     @patch.object(EC2TestingJob, 'send_log')
     def test_testing_run_test(
         self, mock_send_log, mock_test_image, mock_get_key_from_file,


### PR DESCRIPTION
- Pass ssh_user to base job class.
- Move temp key pair handling to a context manager.

GCE and Azure will have similar credential handling (ipa_helper) and eventually EC2 will follow suit.