### PR TITLE
Add support for azure in testing service

### DIFF
--- a/mash/services/testing/azure_job.py
+++ b/mash/services/testing/azure_job.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
 #
 # This file is part of mash.
 #
@@ -16,6 +16,8 @@
 # along with mash.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import json
+
 from threading import Thread
 
 from mash.services.status_levels import FAILED, SUCCESS
@@ -23,18 +25,18 @@ from mash.services.testing.ipa_helper import ipa_test
 from mash.services.testing.job import TestingJob
 
 
-class EC2TestingJob(TestingJob):
+class AzureTestingJob(TestingJob):
     """
-    Class for an EC2 testing job.
+    Class for an Azure testing job.
     """
     __test__ = False
 
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
         job_file=None, credentials=None, description=None, distro='sles',
-        instance_type=None, ssh_user='ec2-user'
+        instance_type=None, ssh_user='azureuser'
     ):
-        super(EC2TestingJob, self).__init__(
+        super(AzureTestingJob, self).__init__(
             id, provider, ssh_private_key_file, test_regions, tests, utctime,
             job_file=job_file, description=description, distro=distro,
             instance_type=instance_type, ssh_user=ssh_user
@@ -48,16 +50,16 @@ class EC2TestingJob(TestingJob):
         jobs = []
         for region, account in self.test_regions.items():
             creds = self.credentials[account]
+            service_account_credentials = json.dumps(creds)
             process = Thread(
                 name=region, target=ipa_test, args=(results,), kwargs={
                     'provider': self.provider,
-                    'access_key_id': creds['access_key_id'],
                     'description': self.description,
                     'distro': self.distro,
                     'image_id': self.source_regions[region],
                     'instance_type': self.instance_type,
                     'region': region,
-                    'secret_access_key': creds['secret_access_key'],
+                    'service_account_credentials': service_account_credentials,
                     'ssh_private_key_file': self.ssh_private_key_file,
                     'ssh_user': self.ssh_user,
                     'tests': self.tests

--- a/mash/services/testing/ipa_helper.py
+++ b/mash/services/testing/ipa_helper.py
@@ -23,6 +23,7 @@ import threading
 from ipa.ipa_controller import test_image
 from tempfile import NamedTemporaryFile
 
+from mash.csp import CSP
 from mash.services.status_levels import EXCEPTION, FAILED, SUCCESS
 from mash.utils.ec2 import get_client
 from mash.utils.mash_utils import generate_name, get_key_from_file
@@ -39,7 +40,7 @@ def ipa_test(
     key_name = None
 
     try:
-        if provider == 'ec2':
+        if provider == CSP.ec2:
             key_name = generate_name()
             client = get_client(
                 'ec2', access_key_id, secret_access_key, region
@@ -78,7 +79,7 @@ def ipa_test(
         results[name] = {'status': status}
     finally:
         try:
-            if provider == 'ec2':
+            if provider == CSP.ec2:
                 client.delete_key_pair(KeyName=key_name)
             else:
                 os.remove(service_account_file)

--- a/mash/services/testing/ipa_helper.py
+++ b/mash/services/testing/ipa_helper.py
@@ -59,7 +59,7 @@ def ipa_test(
             provider,
             access_key_id=access_key_id,
             cleanup=True,
-            desc=description,
+            description=description,
             distro=distro,
             image_id=image_id,
             instance_type=instance_type,

--- a/mash/services/testing/job.py
+++ b/mash/services/testing/job.py
@@ -29,7 +29,8 @@ class TestingJob(object):
 
     def __init__(
         self, id, provider, ssh_private_key_file, test_regions, tests, utctime,
-        job_file=None, description=None, distro='sles', instance_type=None
+        job_file=None, description=None, distro='sles', instance_type=None,
+        ssh_user=None
     ):
         self.cloud_image_name = None
         self.job_file = job_file
@@ -44,6 +45,7 @@ class TestingJob(object):
         self.status = UNKOWN
         self.source_regions = None
         self.ssh_private_key_file = ssh_private_key_file
+        self.ssh_user = ssh_user
         self.test_regions = self.validate_test_regions(test_regions)
         self.tests = tests
         self.utctime = utctime

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -24,6 +24,7 @@ from apscheduler import events
 from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 
+from mash.csp import CSP
 from mash.services.base_service import BaseService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.services.testing.config import TestingConfig
@@ -78,9 +79,9 @@ class TestingService(BaseService):
                 'Job already queued.',
                 extra={'job_id': job_id}
             )
-        elif provider == 'ec2':
+        elif provider == CSP.ec2:
             self._create_job(EC2TestingJob, job_config)
-        elif provider == 'azure':
+        elif provider == CSP.azure:
             self._create_job(AzureTestingJob, job_config)
         else:
             self.log.error(

--- a/mash/services/testing/service.py
+++ b/mash/services/testing/service.py
@@ -27,6 +27,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from mash.services.base_service import BaseService
 from mash.services.status_levels import EXCEPTION, SUCCESS
 from mash.services.testing.config import TestingConfig
+from mash.services.testing.azure_job import AzureTestingJob
 from mash.services.testing.ec2_job import EC2TestingJob
 
 
@@ -79,6 +80,8 @@ class TestingService(BaseService):
             )
         elif provider == 'ec2':
             self._create_job(EC2TestingJob, job_config)
+        elif provider == 'azure':
+            self._create_job(AzureTestingJob, job_config)
         else:
             self.log.error(
                 'Provider {0} is not supported.'.format(provider)

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -49,7 +49,7 @@ class TestAzureTestingJob(object):
             'azure',
             access_key_id=None,
             cleanup=True,
-            desc=job.description,
+            description=job.description,
             distro='sles',
             image_id='ami-123',
             instance_type=None,

--- a/test/unit/services/testing/azure_job_test.py
+++ b/test/unit/services/testing/azure_job_test.py
@@ -1,0 +1,72 @@
+from unittest.mock import call, Mock, patch
+
+from mash.services.testing.azure_job import AzureTestingJob
+
+
+class TestAzureTestingJob(object):
+    def setup(self):
+        self.job_config = {
+            'id': '1',
+            'provider': 'azure',
+            'ssh_private_key_file': 'private_ssh_key.file',
+            'test_regions': {'East US': 'test-azure'},
+            'tests': ['test_stuff'],
+            'utctime': 'now',
+        }
+
+    @patch('mash.services.testing.ipa_helper.NamedTemporaryFile')
+    @patch('mash.services.testing.ipa_helper.test_image')
+    @patch.object(AzureTestingJob, 'send_log')
+    def test_testing_run_azure_test(
+        self, mock_send_log, mock_test_image, mock_temp_file
+    ):
+        tmp_file = Mock()
+        tmp_file.name = '/tmp/acnt.file'
+        mock_temp_file.return_value = tmp_file
+        mock_test_image.return_value = (
+            0,
+            {
+                'tests': '...',
+                'summary': '...',
+                'info': {
+                    'log_file': 'test.log',
+                    'results_file': 'test.results'
+                }
+            }
+        )
+
+        job = AzureTestingJob(**self.job_config)
+        job.credentials = {
+            'test-azure': {
+                'fake': '123',
+                'credentials': '321'
+            }
+        }
+        job.source_regions = {'East US': 'ami-123'}
+        job._run_tests()
+
+        mock_test_image.assert_called_once_with(
+            'azure',
+            access_key_id=None,
+            cleanup=True,
+            desc=job.description,
+            distro='sles',
+            image_id='ami-123',
+            instance_type=None,
+            log_level=30,
+            region='East US',
+            secret_access_key=None,
+            service_account_file='/tmp/acnt.file',
+            ssh_key_name=None,
+            ssh_private_key='private_ssh_key.file',
+            ssh_user='azureuser',
+            tests=['test_stuff']
+        )
+
+        # Failed job test
+        mock_test_image.side_effect = Exception('Tests broken!')
+        job._run_tests()
+        mock_send_log.assert_has_calls(
+            [call('Image tests failed in region: East US.', success=False),
+             call('Tests broken!', success=False)]
+        )

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -57,7 +57,7 @@ class TestEC2TestingJob(object):
             'ec2',
             access_key_id='123',
             cleanup=True,
-            desc=job.description,
+            description=job.description,
             distro='sles',
             image_id='ami-123',
             instance_type=None,

--- a/test/unit/services/testing/ec2_job_test.py
+++ b/test/unit/services/testing/ec2_job_test.py
@@ -64,6 +64,7 @@ class TestEC2TestingJob(object):
             log_level=30,
             region='us-east-1',
             secret_access_key='321',
+            service_account_file=None,
             ssh_key_name='random_name',
             ssh_private_key='private_ssh_key.file',
             ssh_user='ec2-user',

--- a/test/unit/services/testing/service_test.py
+++ b/test/unit/services/testing/service_test.py
@@ -6,6 +6,7 @@ from apscheduler.jobstores.base import JobLookupError
 
 from mash.services.base_service import BaseService
 from mash.services.testing.service import TestingService
+from mash.services.testing.azure_job import AzureTestingJob
 from mash.services.testing.ec2_job import EC2TestingJob
 
 open_name = "builtins.open"
@@ -76,25 +77,37 @@ class TestIPATestingService(object):
     def test_testing_add_job(self, mock_create_job):
         job = Mock()
         job.id = '1'
-        job.get_metadata.return_value = {'job_id': '1', 'provider': 'ec2'}
+        job.get_metadata.return_value = {'job_id': job.id, 'provider': 'ec2'}
 
-        self.testing._add_job({'id': '1', 'provider': 'ec2'})
+        self.testing._add_job({'id': job.id, 'provider': 'ec2'})
 
         mock_create_job.assert_called_once_with(
-            EC2TestingJob, {'id': '1', 'provider': 'ec2'}
+            EC2TestingJob, {'id': job.id, 'provider': 'ec2'}
+        )
+
+    @patch.object(TestingService, '_create_job')
+    def test_testing_add_azure_job(self, mock_create_job):
+        job = Mock()
+        job.id = '1'
+        job.get_metadata.return_value = {'job_id': job.id, 'provider': 'azure'}
+
+        self.testing._add_job({'id': job.id, 'provider': 'azure'})
+
+        mock_create_job.assert_called_once_with(
+            AzureTestingJob, {'id': job.id, 'provider': 'azure'}
         )
 
     def test_testing_add_job_exists(self):
         job = Mock()
         job.id = '1'
-        job.get_metadata.return_value = {'job_id': '1'}
+        job.get_metadata.return_value = {'job_id': job.id}
 
-        self.testing.jobs['1'] = Mock()
-        self.testing._add_job({'id': '1', 'provider': 'ec2'})
+        self.testing.jobs[job.id] = Mock()
+        self.testing._add_job({'id': job.id, 'provider': 'ec2'})
 
         self.testing.log.warning.assert_called_once_with(
             'Job already queued.',
-            extra={'job_id': '1'}
+            extra={'job_id': job.id}
         )
 
     def test_testing_add_job_invalid(self):
@@ -112,24 +125,25 @@ class TestIPATestingService(object):
 
         job = Mock()
         job.id = '1'
-        job.get_metadata.return_value = {'job_id': '1'}
+        job.get_metadata.return_value = {'job_id': job.id}
 
         job_class = Mock()
         job_class.return_value = job
-        job_config = {'id': '1', 'provider': 'ec2'}
+        job_config = {'id': job.id, 'provider': 'ec2'}
         self.testing._create_job(job_class, job_config)
 
         job_class.assert_called_once_with(
-            id='1', provider='ec2', ssh_private_key_file='private_ssh_key.file'
+            id=job.id, provider='ec2',
+            ssh_private_key_file='private_ssh_key.file'
         )
         job.set_log_callback.assert_called_once_with(
             self.testing.log_job_message
         )
         assert job.job_file == 'temp-config.json'
-        mock_bind_listener_queue.assert_called_once_with('1')
+        mock_bind_listener_queue.assert_called_once_with(job.id)
         self.testing.log.info.assert_called_once_with(
             'Job queued, awaiting uploader result.',
-            extra={'job_id': '1'}
+            extra={'job_id': job.id}
         )
 
     def test_testing_create_job_exception(self):
@@ -146,17 +160,17 @@ class TestIPATestingService(object):
     def test_testing_delete_job(self, mock_unbind_queue):
         job = Mock()
         job.id = '1'
-        job.get_metadata.return_value = {'job_id': '1'}
+        job.get_metadata.return_value = {'job_id': job.id}
 
-        self.testing.jobs['1'] = job
-        self.testing._delete_job('1')
+        self.testing.jobs[job.id] = job
+        self.testing._delete_job(job.id)
 
         self.testing.log.info.assert_called_once_with(
             'Deleting job.',
-            extra={'job_id': '1'}
+            extra={'job_id': job.id}
         )
         mock_unbind_queue.assert_called_once_with(
-            'listener', 'testing', '1'
+            'listener', 'testing', job.id
         )
 
     @patch.object(TestingService, '_delete_job')
@@ -167,21 +181,21 @@ class TestIPATestingService(object):
         job.status = "success"
         job.image_id = 'image123'
         job.utctime = 'now'
-        job.get_metadata.return_value = {'job_id': '1'}
+        job.get_metadata.return_value = {'job_id': job.id}
 
         scheduler = Mock()
-        scheduler.remove_job.side_effect = JobLookupError('1')
+        scheduler.remove_job.side_effect = JobLookupError(job.id)
         self.testing.scheduler = scheduler
 
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
         self.testing._cleanup_job(job, 1)
 
         self.testing.log.warning.assert_called_once_with(
             'Failed upstream.',
-            extra={'job_id': '1'}
+            extra={'job_id': job.id}
         )
-        scheduler.remove_job.assert_called_once_with('1')
-        mock_delete_job.assert_called_once_with('1')
+        scheduler.remove_job.assert_called_once_with(job.id)
+        mock_delete_job.assert_called_once_with(job.id)
         mock_publish_message.assert_called_once_with(job)
 
     def test_testing_delete_invalid_job(self):
@@ -200,15 +214,15 @@ class TestIPATestingService(object):
         job = Mock()
         job.id = '1'
         job.utctime = 'always'
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
 
         message = Mock()
         message.body = '{"jwt_token": "response"}'
 
-        mock_decode_credentials.return_value = '1', {'fake': 'creds'}
+        mock_decode_credentials.return_value = job.id, {'fake': 'creds'}
         self.testing._handle_credentials_response(message)
 
-        mock_schedule_job.assert_called_once_with('1')
+        mock_schedule_job.assert_called_once_with(job.id)
         message.ack.assert_called_once_with()
 
     @patch.object(TestingService, 'decode_credentials')
@@ -284,20 +298,22 @@ class TestIPATestingService(object):
         job.utctime = 'now'
         job.status = "success"
         job.iteration_count = 1
-        job.get_metadata.return_value = {'job_id': '1'}
+        job.get_metadata.return_value = {'job_id': job.id}
 
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
         self.testing._process_test_result(event)
 
-        mock_delete_job.assert_called_once_with('1')
+        mock_delete_job.assert_called_once_with(job.id)
         self.testing.log.info.assert_called_once_with(
             'Pass[1]: Testing successful.',
-            extra={'job_id': '1'}
+            extra={'job_id': job.id}
         )
         mock_get_status_message.assert_called_once_with(job)
-        mock_bind_queue.assert_called_once_with('replication', '1', 'listener')
+        mock_bind_queue.assert_called_once_with(
+            'replication', job.id, 'listener'
+        )
         mock_publish.assert_called_once_with(
-            'replication', '1', self.status_message
+            'replication', job.id, self.status_message
         )
 
     def test_testing_process_test_result_exception(self):
@@ -343,19 +359,19 @@ class TestIPATestingService(object):
         job.status = "error"
         job.utctime = 'now'
         job.iteration_count = 1
-        job.get_metadata.return_value = {'job_id': '1'}
+        job.get_metadata.return_value = {'job_id': job.id}
 
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
         self.testing._process_test_result(event)
 
-        mock_delete_job.assert_called_once_with('1')
+        mock_delete_job.assert_called_once_with(job.id)
         self.testing.log.error.assert_called_once_with(
             'Pass[1]: Error occurred testing image with IPA.',
-            extra={'job_id': '1'}
+            extra={'job_id': job.id}
         )
         mock_get_status_message.assert_called_once_with(job)
         mock_publish.assert_called_once_with(
-            'replication', '1', self.error_message
+            'replication', job.id, self.error_message
         )
 
     @patch.object(TestingService, 'bind_queue')
@@ -369,9 +385,11 @@ class TestIPATestingService(object):
         job.source_regions = {'us-east-2': 'ami-123456'}
 
         self.testing._publish_message(job)
-        mock_bind_queue.assert_called_once_with('replication', '1', 'listener')
+        mock_bind_queue.assert_called_once_with(
+            'replication', job.id, 'listener'
+        )
         mock_publish.assert_called_once_with(
-            'replication', '1', self.status_message
+            'replication', job.id, self.status_message
         )
 
     @patch.object(TestingService, 'bind_queue')
@@ -383,15 +401,15 @@ class TestIPATestingService(object):
         job.image_id = 'image123'
         job.id = '1'
         job.status = "error"
-        job.get_metadata.return_value = {'job_id': '1'}
+        job.get_metadata.return_value = {'job_id': job.id}
 
         mock_publish.side_effect = AMQPError('Broken')
         self.testing._publish_message(job)
 
-        mock_bind_queue.assert_called_once_with('replication', '1', 'listener')
+        mock_bind_queue.assert_called_once_with('replication', job.id, 'listener')
         self.testing.log.warning.assert_called_once_with(
             'Message not received: {0}'.format(self.error_message),
-            extra={'job_id': '1'}
+            extra={'job_id': job.id}
         )
 
     def test_testing_run_test(self):
@@ -431,7 +449,7 @@ class TestIPATestingService(object):
         job.id = '1'
         job.utctime = 'always'
         job.credentials = None
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
 
         mock_validate_listener_msg.return_value = job
 
@@ -444,8 +462,8 @@ class TestIPATestingService(object):
 
         self.testing._handle_listener_message(self.message)
 
-        assert self.testing.jobs['1'].listener_msg == self.message
-        mock_pub_cred_request.assert_called_once_with('1')
+        assert self.testing.jobs[job.id].listener_msg == self.message
+        mock_pub_cred_request.assert_called_once_with(job.id)
 
     @patch.object(TestingService, '_schedule_job')
     @patch.object(TestingService, '_validate_listener_msg')
@@ -457,7 +475,7 @@ class TestIPATestingService(object):
         job.id = '1'
         job.utctime = 'always'
         job.credentials = {'credentials': 'info'}
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
 
         mock_validate_listener_msg.return_value = job
 
@@ -470,8 +488,8 @@ class TestIPATestingService(object):
 
         self.testing._handle_listener_message(self.message)
 
-        assert self.testing.jobs['1'].listener_msg == self.message
-        mock_schedule_job.assert_called_once_with('1')
+        assert self.testing.jobs[job.id].listener_msg == self.message
+        mock_schedule_job.assert_called_once_with(job.id)
 
     @patch.object(TestingService, '_validate_listener_msg')
     def test_testing_handle_listener_message_no_job(
@@ -489,7 +507,7 @@ class TestIPATestingService(object):
         job.id = '1'
         job.utctime = 'always'
         job.test_regions = {'us-east-1': {'account': 'test-aws'}}
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
 
         self.message.body = \
             '{"uploader_result": {"id": "1", ' \
@@ -546,7 +564,7 @@ class TestIPATestingService(object):
         job = Mock()
         job.id = '1'
         job.utctime = 'always'
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
 
         self.message.body = \
             '{"uploader_result": {"id": "1", ' \
@@ -562,7 +580,7 @@ class TestIPATestingService(object):
         job = Mock()
         job.id = '1'
         job.utctime = 'always'
-        self.testing.jobs['1'] = job
+        self.testing.jobs[job.id] = job
 
         self.message.body = \
             '{"uploader_result": {"id": "1", "status": "success"}}'


### PR DESCRIPTION
- Add azure testing job.
- Handle temp service account files in ipa helper.
- Clean up job id references in test to use job.id value and not string literal.

resolves #198 