### PR TITLE
Delete job description validation from uploader

### DIFF
--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -199,13 +199,9 @@ class UploadImageService(BaseService):
           }
         }
         """
-        job_info = self._validate_job_description(data)
-        if not job_info['ok']:
-            return job_info
-        else:
-            data = data['uploader_job']
-            data['job_file'] = self.persist_job_config(data)
-            return self._schedule_job(data)
+        data = data['uploader_job']
+        data['job_file'] = self.persist_job_config(data)
+        return self._schedule_job(data)
 
     def _delete_job(self, job_id):
         """
@@ -235,69 +231,6 @@ class UploadImageService(BaseService):
                     'ok': True,
                     'message': 'Job Deleted'
                 }
-
-    def _validate_job_description(self, job_data):
-        # validate job description. Currently only Amazon ec2 is supported
-        if 'uploader_job' not in job_data:
-            return {
-                'ok': False,
-                'message': 'Invalid job: no uploader_job'
-            }
-        job = job_data['uploader_job']
-        if 'id' not in job:
-            return {
-                'ok': False,
-                'message': 'Invalid job: no job id'
-            }
-        if job['id'] in self.jobs:
-            return {
-                'ok': False,
-                'message': 'Job already exists'
-            }
-        if 'cloud_image_name' not in job:
-            return {
-                'ok': False,
-                'message': 'Invalid job: no cloud image name'
-            }
-        if 'image_description' not in job:
-            return {
-                'ok': False,
-                'message': 'Invalid job: no cloud image description'
-            }
-        if 'provider' not in job:
-            return {
-                'ok': False,
-                'message': 'Invalid job: no cloud provider'
-            }
-        if job['provider'] != CSP.ec2:
-            return {
-                'ok': False,
-                'message': 'Invalid job: {0} provider not supported'.format(
-                    job['provider']
-                )
-            }
-        if 'target_regions' not in job:
-            return {
-                'ok': False,
-                'message': 'Invalid job: no target regions record'
-            }
-        if 'utctime' not in job:
-            return {
-                'ok': False,
-                'message': 'Invalid job: no time given'
-            }
-        elif job['utctime'] != 'now' and job['utctime'] != 'always':
-            try:
-                dateutil.parser.parse(job['utctime']).isoformat()
-            except Exception as e:
-                return {
-                    'ok': False,
-                    'message': 'Invalid job time: {0}'.format(e)
-                }
-        return {
-            'ok': True,
-            'message': 'OK'
-        }
 
     def _get_uploader_arguments_per_region(self, job_data):
         uploader_args = []

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -196,13 +196,10 @@ class TestUploadImageService(object):
         ]
 
     @patch.object(UploadImageService, 'persist_job_config')
-    @patch.object(UploadImageService, '_validate_job_description')
     @patch.object(UploadImageService, '_schedule_job')
     @patch_open
     def test_add_job(
-        self, mock_open,
-        mock_schedule_job, mock_validate_job_description,
-        mock_persist_job_config
+        self, mock_open, mock_schedule_job, mock_persist_job_config
     ):
         job_data = {
             "uploader_job": {
@@ -219,20 +216,8 @@ class TestUploadImageService(object):
                 "utctime": "now"
             }
         }
-        job_info = {
-            'ok': False
-        }
-        mock_validate_job_description.return_value = job_info
-        assert self.uploader._add_job(job_data) == job_info
-        job_info = {
-            'ok': True
-        }
-        mock_validate_job_description.return_value = job_info
         self.uploader._add_job(job_data)
         mock_schedule_job.assert_called_once_with(job_data['uploader_job'])
-        assert mock_validate_job_description.call_args_list == [
-            call(job_data), call(job_data)
-        ]
         mock_persist_job_config.assert_called_once_with(
             job_data['uploader_job']
         )
@@ -254,101 +239,6 @@ class TestUploadImageService(object):
         mock_os_remove.side_effect = Exception('remove_error')
         assert self.uploader._delete_job('815') == {
             'message': 'Job deletion failed: remove_error', 'ok': False
-        }
-
-    @patch('mash.services.uploader.service.dateutil.parser.parse')
-    def test_validate_job_description(self, mock_dateutil_parse):
-        mock_dateutil_parse.side_effect = Exception('mytime')
-        job_data = {}
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: no uploader_job', 'ok': False
-        }
-        job_data = {"uploader_job": {}}
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: no job id', 'ok': False
-        }
-        job_data = {"uploader_job": {"id": "123"}}
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: no cloud image name', 'ok': False
-        }
-        job_data = {"uploader_job": {"id": "123", "cloud_image_name": "foo"}}
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: no cloud image description', 'ok': False
-        }
-        job_data = {
-            "uploader_job": {
-                "id": "123",
-                "cloud_image_name": "foo",
-                "image_description": "bar"
-            }
-        }
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: no cloud provider', 'ok': False
-        }
-        job_data = {
-            "uploader_job": {
-                "id": "123",
-                "cloud_image_name": "foo",
-                "image_description": "bar",
-                "provider": "EC2"
-            }
-        }
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: EC2 provider not supported', 'ok': False
-        }
-        job_data = {
-            "uploader_job": {
-                "id": "123",
-                "cloud_image_name": "foo",
-                "image_description": "bar",
-                "provider": "ec2"
-            }
-        }
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: no target regions record', 'ok': False
-        }
-        job_data = {
-            "uploader_job": {
-                "id": "123",
-                "cloud_image_name": "foo",
-                "image_description": "bar",
-                "provider": "ec2",
-                "target_regions": {
-                    "us-east-1": {
-                        "helper_image": "ami-bc5b48d0",
-                        "account": "test-aws"
-                    }
-                }
-            }
-        }
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job: no time given', 'ok': False
-        }
-        job_data = {
-            "uploader_job": {
-                "id": "123",
-                "cloud_image_name": "foo",
-                "image_description": "bar",
-                "provider": "ec2",
-                "target_regions": {
-                    "us-east-1": {
-                        "helper_image": "ami-bc5b48d0",
-                        "account": "test-aws"
-                    }
-                },
-                "utctime": "mytime"
-            }
-        }
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Invalid job time: mytime', 'ok': False
-        }
-        mock_dateutil_parse.side_effect = None
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'OK', 'ok': True
-        }
-        self.uploader.jobs = {'123': None}
-        assert self.uploader._validate_job_description(job_data) == {
-            'message': 'Job already exists', 'ok': False
         }
 
     @patch.object(UploadImageService, 'publish_credentials_request')


### PR DESCRIPTION
The validation of the job description has been moved one level
up to the job creator service which applies a json validation
on the request send to the job creator service. It is expected
that the job descriptions created by the job creator service
are valid and doesn't need a validation by the receiving
service. This Fixes #196