### PR TITLE
Use uploader_result key.

### DIFF
--- a/mash/services/uploader/service.py
+++ b/mash/services/uploader/service.py
@@ -88,7 +88,7 @@ class UploadImageService(BaseService):
         if last_upload_region:
             self.publish_job_result(
                 'testing', job_id, JsonFormat.json_message(
-                    self.jobs[job_id]['uploader_result']
+                    {'uploader_result': self.jobs[job_id]['uploader_result']}
                 )
             )
             if not self.jobs[job_id]['nonstop']:

--- a/test/unit/services/uploader/service_test.py
+++ b/test/unit/services/uploader/service_test.py
@@ -98,7 +98,8 @@ class TestUploadImageService(object):
         self.uploader._send_job_result('815', True, trigger_info)
         mock_publish_job_result.assert_called_once_with(
             'testing', '815', JsonFormat.json_message(
-                self.uploader.jobs['815']['uploader_result']
+                {'uploader_result':
+                 self.uploader.jobs['815']['uploader_result']}
             )
         )
         mock_delete_job.assert_called_once_with('815')


### PR DESCRIPTION
Uploader result data should be under the 'uploader_result' key.

@schaefi Added an issue to consider using jwt for these messages as well #209. Maybe to consider for MASH next?