### PR TITLE
Fix upload image return value.

### DIFF
--- a/mash/services/uploader/upload_image.py
+++ b/mash/services/uploader/upload_image.py
@@ -102,7 +102,7 @@ class UploadImage(object):
                 self.custom_uploader_args
             )
             try:
-                (self.upload_region, self.cloud_image_id) = \
+                self.cloud_image_id, self.upload_region = \
                     self.uploader.upload()
                 self._log_callback(
                     'Uploaded image has ID: {0}'.format(self.cloud_image_id)

--- a/test/unit/services/uploader/upload_image_test.py
+++ b/test/unit/services/uploader/upload_image_test.py
@@ -24,7 +24,7 @@ class TestUploadImage(object):
         self, mock_result_callback, mock_log_callback, mock_Upload
     ):
         uploader = Mock()
-        uploader.upload.return_value = ['region', 'image_id']
+        uploader.upload.return_value = ('image_id', 'region')
         mock_Upload.return_value = uploader
         self.upload_image.upload()
         mock_Upload.assert_called_once_with(


### PR DESCRIPTION
I didn't catch the listener message for debugging but it appears the region and image ID got swapped so I got an error in testing service:

`Pass[1]: Exception testing image: 'ca-central-1'`

https://github.com/SUSE/mash/blob/master/mash/services/uploader/cloud/amazon.py#L109