### PR TITLE
Add Azure account examples.

### DIFF
--- a/examples/accounts.json
+++ b/examples/accounts.json
@@ -39,6 +39,24 @@
       "us-west-2": "ami-f0091d91"
     }
   },
-  "azure": {},
+  "azure": {
+    "groups": {
+      "group1": ["azure-china", "azure"]
+    },
+    "accounts": {
+      "azure-china": {
+        "region": "China East",
+        "resource_group": "cn_res_group",
+        "container_name": "cncontainer1",
+        "storage_account": "cnstorage1"
+      },
+      "azure": {  
+        "region": "East US 2",
+        "resource_group": "res_group_2",
+        "container_name": "container2",
+        "storage_account": "storage2"
+      }
+    }
+  },
   "gce": {}
 }


### PR DESCRIPTION
@rjschwei Given Azure has no replication in ARM I don't think we need the list of regions per "partition". So the idea is that when an Azure account is added to MASH we expect the; target region, resource group, container name and storage account.

The upload would always go to the same location based on that info for always/persistent jobs.