### PR TITLE
Update job creator message queue consuming.

### DIFF
--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -82,6 +82,8 @@ class BaseService(object):
             self.service_exchange
         )
 
+        self.add_account_key = 'add_account'
+
         logging.basicConfig()
         self.log = logging.getLogger(self.__class__.__name__)
         self.log.setLevel(logging.DEBUG)


### PR DESCRIPTION
- Ensure queues are consumed before starting consuming.
- Move exception handling to start method
- Bind add_account_key to listener queue

- Add delete job message handling.