### PR TITLE
Implement job creator message handling

### DIFF
--- a/mash/services/jobcreator/__init__.py
+++ b/mash/services/jobcreator/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from jsonschema import FormatChecker, validate
+
+from mash.csp import CSP
+from mash.mash_exceptions import (
+    MashJobCreatorException,
+    MashValidationException
+)
+from mash.services.jobcreator import schema
+from mash.services.jobcreator.ec2_job import EC2Job
+
+
+def create_job(job_doc, accounts_info):
+    csp_name = job_doc.get('provider')
+    accounts_info = accounts_info.get(csp_name)
+
+    if csp_name == CSP.ec2:
+        job_class = EC2Job
+        message_schema = schema.ec2_job_message
+    else:
+        raise MashJobCreatorException(
+            'Support for {csp} Cloud Service not implemented'.format(
+                csp=csp_name
+            )
+        )
+
+    try:
+        validate(job_doc, message_schema, format_checker=FormatChecker())
+    except Exception as error:
+        raise MashValidationException(error)
+    else:
+        return job_class(accounts_info, **job_doc)

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import json
+import uuid
+
+
+class BaseJob(object):
+    """
+    Base job message class.
+
+    Handles incoming job requests.
+    """
+    def __init__(
+            self, accounts_info, provider, provider_accounts,
+            provider_groups, requesting_user, last_service, utctime, image,
+            cloud_image_name, old_cloud_image_name, project,
+            image_description, distro, tests,
+            conditions=None, instance_type=None
+    ):
+        self.id = str(uuid.uuid4())
+        self.accounts_info = accounts_info
+        self.provider = provider
+        self.provider_accounts = provider_accounts
+        self.provider_groups = provider_groups
+        self.requesting_user = requesting_user
+        self.last_service = last_service
+        self.image = image
+        self.cloud_image_name = cloud_image_name
+        self.old_cloud_image_name = old_cloud_image_name
+        self.project = project
+        self.image_description = image_description
+        self.distro = distro
+        self.tests = tests
+        self.conditions = conditions
+        self.instance_type = instance_type
+        self.utctime = utctime
+
+        self.base_message = {'id': self.id, 'utctime': self.utctime}
+
+        self.post_init()
+
+    def _get_account_info(self):
+        """
+        Parse dictionary of account data from accounts file.
+
+        Implementation in child class.
+        """
+        pass
+
+    def _get_accounts_in_group(self, group):
+        """
+        Return a list of account names given the group name.
+        """
+        return self.accounts_info['groups'][group]
+
+    def get_credentials_message(self):
+        """
+        Build credentials job message.
+        """
+        accounts = []
+        for source_region, value in self.target_account_info.items():
+            accounts.append(value['account'])
+
+        credentials_message = {
+            'credentials_job': {
+                'provider': self.provider,
+                'last_service': self.last_service,
+                'provider_accounts': accounts,
+                'requesting_user': self.requesting_user
+            }
+        }
+        credentials_message['credentials_job'].update(self.base_message)
+
+        return json.dumps(credentials_message)
+
+    def get_deprecation_message(self):
+        """
+        Build deprecation job message.
+        """
+        deprecation_message = {
+            'deprecation_job': {
+                'provider': self.provider,
+                'old_cloud_image_name': self.old_cloud_image_name,
+                'deprecation_regions': self.get_deprecation_regions()
+            }
+        }
+        deprecation_message['deprecation_job'].update(self.base_message)
+
+        return json.dumps(deprecation_message)
+
+    def get_deprecation_regions(self):
+        """
+        Return list of deprecation region info.
+
+        Implementation in child class.
+        """
+        pass
+
+    def get_obs_message(self):
+        """
+        Build OBS job message.
+        """
+        obs_message = {
+            'obs_job': {
+                'image': self.image,
+                'project': self.project,
+            }
+        }
+        obs_message['obs_job'].update(self.base_message)
+
+        if self.conditions:
+            obs_message['obs_job']['conditions'] = self.conditions
+
+        return json.dumps(obs_message)
+
+    def get_pint_message(self):
+        """
+        Build pint job message.
+        """
+        pint_message = {
+            'pint_job': {
+                'provider': self.provider,
+                'cloud_image_name': self.cloud_image_name,
+                'old_cloud_image_name': self.old_cloud_image_name
+            }
+        }
+        pint_message['pint_job'].update(self.base_message)
+
+        return json.dumps(pint_message)
+
+    def get_publisher_message(self):
+        """
+        Build publisher job message.
+
+        Implementation in child class.
+        """
+        pass
+
+    def get_replication_message(self):
+        """
+        Build replication job message and publish to replication exchange.
+        """
+        replication_message = {
+            'replication_job': {
+                'image_description': self.image_description,
+                'provider': self.provider,
+                'replication_source_regions':
+                    self.get_replication_source_regions()
+            }
+        }
+        replication_message['replication_job'].update(self.base_message)
+
+        return json.dumps(replication_message)
+
+    def get_replication_source_regions(self):
+        """
+        Return a dictionary of replication source regions.
+
+        Implementation in child class.
+        """
+        pass
+
+    def get_testing_message(self):
+        """
+        Build testing job message.
+        """
+        testing_message = {
+            'testing_job': {
+                'provider': self.provider,
+                'tests': self.tests,
+                'test_regions': self.get_testing_regions()
+            }
+        }
+
+        if self.distro:
+            testing_message['testing_job']['distro'] = self.distro
+
+        if self.instance_type:
+            testing_message['testing_job']['instance_type'] = \
+                self.instance_type
+
+        testing_message['testing_job'].update(self.base_message)
+
+        return json.dumps(testing_message)
+
+    def get_testing_regions(self):
+        """
+        Return a dictionary of target test regions.
+
+        Implementation in child class.
+        """
+        pass
+
+    def get_uploader_message(self):
+        """
+        Build uploader job message.
+        """
+        uploader_message = {
+            'uploader_job': {
+                'cloud_image_name': self.cloud_image_name,
+                'provider': self.provider,
+                'image_description': self.image_description,
+                'target_regions': self.get_uploader_regions()
+            }
+        }
+        uploader_message['uploader_job'].update(self.base_message)
+
+        return json.dumps(uploader_message)
+
+    def get_uploader_regions(self):
+        """
+        Return a dictionary of target uploader regions.
+
+        Implementation in child class.
+        """
+        pass
+
+    def post_init(self):
+        """
+        Post initialization method.
+
+        Implementation in child class.
+        """
+        pass

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import json
+import random
+
+from mash.services.jobcreator.base_job import BaseJob
+
+
+class EC2Job(BaseJob):
+    """
+    Base job message class.
+
+    Handles incoming job requests.
+    """
+    def __init__(
+            self, accounts_info, provider, provider_accounts, provider_groups,
+            requesting_user, last_service, utctime, image,
+            cloud_image_name, old_cloud_image_name, project,
+            share_with, allow_copy, image_description, distro,
+            tests, conditions=None, instance_type=None
+    ):
+        self.share_with = share_with
+        self.allow_copy = allow_copy
+        self.target_account_info = {}
+
+        super(EC2Job, self).__init__(
+            accounts_info, provider, provider_accounts, provider_groups,
+            requesting_user, last_service, utctime, image, cloud_image_name,
+            old_cloud_image_name, project, image_description, distro, tests,
+            conditions, instance_type
+        )
+
+    def _get_account_info(self):
+        """
+        Returns a dictionary of accounts and regions.
+
+        The provided target_regions dictionary may contain a list
+        of groups and accounts. An account may have a list of regions.
+
+        If regions are not provided for an account the default list
+        of all regions available is used.
+
+        Example: {
+            'us-east-1': {
+                'account': 'acnt1',
+                'target_regions': ['us-east-2', 'us-west-1', 'us-west-2']
+            }
+        }
+        """
+        group_accounts = []
+        accounts = {}
+
+        # Get dictionary of account names to target regions
+        for provider_account in self.provider_accounts:
+            accounts[provider_account['name']] = \
+                provider_account['target_regions']
+
+        helper_images = self.accounts_info.get('helper_images')
+
+        # Get all accounts from all groups
+        for group in self.provider_groups:
+            group_accounts += self._get_accounts_in_group(group)
+
+        # Add accounts from groups that don't already exist
+        for account in group_accounts:
+            if account not in accounts:
+                accounts[account] = None
+
+        for account, target_regions in accounts.items():
+            if not target_regions:
+                # Get default list of all available regions for account
+                target_regions = self._get_regions_for_account(account)
+
+            # A random region is selected as source region.
+            target = random.choice(target_regions)
+            self.target_account_info[target] = {
+                'account': account,
+                'target_regions': target_regions,
+                'helper_image': helper_images[target]
+            }
+
+    def _get_regions_for_account(self, account):
+        """
+        Return a list of regions based on account name.
+        """
+        regions_key = self.accounts_info['accounts'][account]
+        return self.accounts_info['regions'][regions_key]
+
+    def _get_target_regions_list(self):
+        """
+        Return list of region info.
+        """
+        regions = []
+
+        for source_region, value in self.target_account_info.items():
+            regions.append(value)
+
+        return regions
+
+    def get_deprecation_regions(self):
+        """
+        Return list of deprecation region info.
+
+        """
+        return self._get_target_regions_list()
+
+    def get_publisher_message(self):
+        """
+        Build publisher job message.
+        """
+        publisher_message = {
+            'publisher_job': {
+                'provider': self.provider,
+                'allow_copy': self.allow_copy,
+                'share_with': self.share_with,
+                'publish_regions': self.get_publisher_regions()
+            }
+        }
+        publisher_message['publisher_job'].update(self.base_message)
+
+        return json.dumps(publisher_message)
+
+    def get_publisher_regions(self):
+        """
+        Return a list of publisher region info.
+        """
+        return self._get_target_regions_list()
+
+    def get_replication_source_regions(self):
+        """
+        Return a dictionary of replication source regions.
+        """
+        replication_source_regions = {}
+
+        for source_region, value in self.target_account_info.items():
+            replication_source_regions[source_region] = {
+                'account': value['account'],
+                'target_regions': value['target_regions']
+            }
+
+        return replication_source_regions
+
+    def get_testing_regions(self):
+        """
+        Return a dictionary of target test regions.
+        """
+        test_regions = {}
+
+        for source_region, value in self.target_account_info.items():
+            test_regions[source_region] = value['account']
+
+        return test_regions
+
+    def get_uploader_regions(self):
+        """
+        Return a dictionary of target uploader regions.
+        """
+        target_regions = {}
+
+        for source_region, value in self.target_account_info.items():
+            target_regions[source_region] = {
+                'account': value['account'],
+                'helper_image': value['helper_image']
+            }
+
+        return target_regions
+
+    def post_init(self):
+        """
+        Post initialization method.
+        """
+        self._get_account_info()

--- a/mash/services/jobcreator/schema.py
+++ b/mash/services/jobcreator/schema.py
@@ -45,10 +45,10 @@ add_account_ec2 = {
 }
 
 
-job_message = {
+ec2_job_message = {
     'type': 'object',
     'properties': {
-        'provider': {'enum': ['azure', 'ec2']},
+        'provider': {'enum': ['ec2']},
         'provider_accounts': {
             'type': 'array',
             'items': {'$ref': '#definitions/account'}

--- a/test/data/accounts.json
+++ b/test/data/accounts.json
@@ -1,0 +1,20 @@
+{
+  "ec2": {
+    "regions": {
+      "aws": ["ap-northeast-1", "ap-northeast-2"],
+      "aws-us-gov": ["us-gov-west-1"]
+    },
+    "groups": {
+      "test": ["test-aws-gov", "test-aws"]
+    },
+    "accounts": {
+      "test-aws-gov": "aws-us-gov",
+      "test-aws": "aws"
+    },
+    "helper_images": {
+      "ap-northeast-1": "ami-383c1956",
+      "ap-northeast-2": "ami-249b554a",
+      "us-gov-west-1": "ami-c2b5d7e1"
+    }
+  }
+}

--- a/test/data/job.json
+++ b/test/data/job.json
@@ -1,0 +1,41 @@
+{
+  "provider": "ec2",
+  "provider_accounts": [
+    {
+      "name": "test-aws-gov",
+      "target_regions": [
+        "us-gov-west-1"
+      ]
+    }
+  ],
+  "provider_groups": [
+    "test"
+  ],
+  "requesting_user": "user1",
+  "last_service": "pint",
+  "utctime": "now",
+  "image": "test_image_oem",
+  "cloud_image_name": "new_image_123",
+  "old_cloud_image_name": "old_new_image_123",
+  "project": "Cloud:Tools",
+  "conditions": [
+    {
+      "package": [
+        "name",
+        "and",
+        "constraints"
+      ]
+    },
+    {
+      "image": "version"
+    }
+  ],
+  "share_with": "all",
+  "allow_copy": false,
+  "image_description": "New Image #123",
+  "distro": "sles",
+  "instance_type": "t2.micro",
+  "tests": [
+    "test_stuff"
+  ]
+}

--- a/test/unit/services/jobcreator/base_job_test.py
+++ b/test/unit/services/jobcreator/base_job_test.py
@@ -1,0 +1,23 @@
+from mash.services.jobcreator.base_job import BaseJob
+
+
+class TestJobCreatorBaseJob(object):
+    def setup(self):
+        self.job = BaseJob(
+            {}, 'ec2', ['test-aws'], [], 'test-user', 'pint', 'now',
+            'test-image', 'test-cloud-image', 'test-old-cloud-image-name',
+            'test-project', 'image description', 'sles', 'test-stuff',
+            [{"package": ["name", "and", "constraints"]}],
+            'instance type'
+        )
+
+    def test_base_job_empty_methods(self):
+        # Test methods that are extended by child classes
+        # base methods just pass
+        self.job._get_account_info()
+        self.job.get_deprecation_regions()
+        self.job.get_publisher_message()
+        self.job.get_replication_source_regions()
+        self.job.get_testing_regions()
+        self.job.get_uploader_regions()
+        self.job.post_init()

--- a/test/unit/services/jobcreator/factory_test.py
+++ b/test/unit/services/jobcreator/factory_test.py
@@ -1,0 +1,29 @@
+from pytest import raises
+from unittest.mock import patch
+
+from mash.mash_exceptions import (
+    MashJobCreatorException,
+    MashValidationException
+)
+from mash.services.jobcreator import create_job
+
+
+@patch('mash.services.jobcreator.validate')
+def test_job_creator_create_job(mock_validate):
+    # invalid provider
+    with raises(MashJobCreatorException) as error:
+        create_job({'provider': 'fake'}, {})
+
+    assert str(error.value) == \
+        'Support for fake Cloud Service not implemented'
+
+    mock_validate.side_effect = MashValidationException(
+        'Validation failed for provided job doc.'
+    )
+
+    # invalid job doc
+    with raises(MashValidationException) as error:
+        create_job({'provider': 'ec2'}, {'ec2': {}})
+
+    assert str(error.value) == \
+        'Validation failed for provided job doc.'

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -1,3 +1,5 @@
+import json
+
 from pytest import raises
 from unittest.mock import call, MagicMock, Mock, patch
 
@@ -28,17 +30,23 @@ class TestJobCreatorService(object):
         self.jobcreator = JobCreatorService()
         self.jobcreator.log = Mock()
         self.jobcreator.add_account_key = 'add_account'
+        self.jobcreator.accounts_file = '../data/accounts.json'
+        self.jobcreator.encryption_keys_file = '../data/encryption_keys'
         self.jobcreator.service_exchange = 'jobcreator'
         self.jobcreator.listener_queue = 'listener'
         self.jobcreator.job_document_key = 'job_document'
+        self.jobcreator.services = [
+            'obs', 'uploader', 'testing', 'replication',
+            'publisher', 'deprecation', 'pint'
+        ]
 
+    @patch.object(JobCreatorService, 'bind_queue')
     @patch.object(JobCreatorService, 'set_logfile')
     @patch.object(JobCreatorService, 'start')
     @patch('mash.services.jobcreator.service.JobCreatorConfig')
-    @patch.object(JobCreatorService, 'bind_queue')
     def test_job_creator_post_init(
-        self, mock_bind_queue, mock_jobcreator_config,
-        mock_start, mock_set_logfile
+        self, mock_jobcreator_config, mock_start, mock_set_logfile,
+        mock_bind_queue
     ):
         mock_jobcreator_config.return_value = self.config
         self.config.get_log_file.return_value = \
@@ -50,13 +58,128 @@ class TestJobCreatorService(object):
         mock_set_logfile.assert_called_once_with(
             '/var/log/mash/job_creator_service.log'
         )
+
         mock_bind_queue.assert_called_once_with(
             'jobcreator', 'add_account', 'listener'
         )
         mock_start.assert_called_once_with()
 
+    @patch('mash.services.jobcreator.ec2_job.random')
+    @patch('mash.services.jobcreator.base_job.uuid')
     @patch.object(JobCreatorService, '_publish')
-    def test_publish_delete_job_message(self, mock_publish):
+    def test_jobcreator_handle_service_message(
+            self, mock_publish, mock_uuid, mock_random
+    ):
+        message = MagicMock()
+
+        uuid_val = '12345678-1234-1234-1234-123456789012'
+        mock_uuid.uuid4.return_value = uuid_val
+
+        mock_random.choice.side_effect = [
+            'us-gov-west-1', 'ap-northeast-1'
+        ]
+
+        with open('../data/job.json', 'r') as accounts_file:
+            message.body = json.dumps(json.load(accounts_file))
+
+        self.jobcreator._handle_service_message(message)
+
+        mock_publish.assert_has_calls([
+            call(
+                'credentials', 'job_document',
+                '{"credentials_job": {"provider": "ec2", '
+                '"last_service": "pint", '
+                '"provider_accounts": ["test-aws-gov", "test-aws"], '
+                '"requesting_user": "user1", '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now"}}'
+            ),
+            call(
+                'obs', 'job_document',
+                '{"obs_job": {"image": "test_image_oem", '
+                '"project": "Cloud:Tools", '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now", '
+                '"conditions": [{"package": ["name", "and", "constraints"]}, '
+                '{"image": "version"}]}}'
+            ),
+            call(
+                'uploader', 'job_document',
+                '{"uploader_job": {"cloud_image_name": "new_image_123", '
+                '"provider": "ec2", "image_description": "New Image #123", '
+                '"target_regions": {"us-gov-west-1": {"account": '
+                '"test-aws-gov", "helper_image": "ami-c2b5d7e1"}, '
+                '"ap-northeast-1": {"account": "test-aws", '
+                '"helper_image": "ami-383c1956"}}, '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now"}}'
+            ),
+            call(
+                'testing', 'job_document',
+                '{"testing_job": {"provider": "ec2", "tests": ["test_stuff"], '
+                '"test_regions": {"us-gov-west-1": "test-aws-gov", '
+                '"ap-northeast-1": "test-aws"}, "distro": "sles", '
+                '"instance_type": "t2.micro", '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now"}}'
+            ),
+            call(
+                'replication', 'job_document',
+                '{"replication_job": {"image_description": "New Image #123", '
+                '"provider": "ec2", "replication_source_regions": {'
+                '"us-gov-west-1": {"account": "test-aws-gov", '
+                '"target_regions": ["us-gov-west-1"]}, "ap-northeast-1": '
+                '{"account": "test-aws", "target_regions": ["ap-northeast-1", '
+                '"ap-northeast-2"]}}, '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now"}}'
+            ),
+            call(
+                'publisher', 'job_document',
+                '{"publisher_job": {"provider": "ec2", "allow_copy": false, '
+                '"share_with": "all", "publish_regions": ['
+                '{"account": "test-aws-gov", "target_regions": '
+                '["us-gov-west-1"], "helper_image": "ami-c2b5d7e1"}, '
+                '{"account": "test-aws", "target_regions": '
+                '["ap-northeast-1", "ap-northeast-2"], "helper_image": '
+                '"ami-383c1956"}], '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now"}}'
+            ),
+            call(
+                'deprecation', 'job_document',
+                '{"deprecation_job": {"provider": "ec2", '
+                '"old_cloud_image_name": "old_new_image_123", '
+                '"deprecation_regions": [{"account": "test-aws-gov", '
+                '"target_regions": ["us-gov-west-1"], '
+                '"helper_image": "ami-c2b5d7e1"}, {"account": "test-aws", '
+                '"target_regions": ["ap-northeast-1", "ap-northeast-2"], '
+                '"helper_image": "ami-383c1956"}], '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now"}}'
+            ),
+            call(
+                'pint', 'job_document',
+                '{"pint_job": {"provider": "ec2", "cloud_image_name": '
+                '"new_image_123", "old_cloud_image_name": '
+                '"old_new_image_123", '
+                '"id": "12345678-1234-1234-1234-123456789012", '
+                '"utctime": "now"}}'
+            )
+        ])
+
+    def test_jobcreator_handle_invalid_service_message(self):
+        message = MagicMock()
+        message.body = 'invalid message'
+
+        self.jobcreator._handle_service_message(message)
+        self.jobcreator.log.error.assert_called_once_with(
+            'Invalid message received: '
+            'Expecting value: line 1 column 1 (char 0).'
+        )
+
+    @patch.object(JobCreatorService, '_publish')
+    def test_jobcreator_publish_delete_job_message(self, mock_publish):
         message = MagicMock()
         message.body = '{"job_delete": "1"}'
         self.jobcreator._handle_service_message(message)


### PR DESCRIPTION
Split into subsequent commits so they can be reviewed separately:

- Rename job schema for EC2 only, each provider will have different requirements and options.
- Add base and EC2 job classes for handling service job docs
- Add factory method to handle validation and creation of job class instances
- Update service class to integrate service message handling of new jobs
- Update/add unit tests