### PR TITLE
Add requesting user to groups and accounts

### DIFF
--- a/examples/accounts.json
+++ b/examples/accounts.json
@@ -11,11 +11,20 @@
       "aws-us-gov": ["us-gov-west-1"]
     },
     "groups": {
-      "GROUP_ONE": ["ACCOUNT_ONE", "ACCOUNT_TWO"]
+      "GROUP_ONE": {
+        "accounts": ["ACCOUNT_ONE", "ACCOUNT_TWO"],
+        "requesting_user": "user1"
+      }
     },
     "accounts": {
-      "ACCOUNT_ONE": "aws-cn",
-      "ACCOUNT_TWO": "aws"
+      "ACCOUNT_ONE": {
+        "partition": "aws-cn",
+        "requesting_user": "user2"
+      },
+      "ACCOUNT_TWO": {
+        "partition": "aws",
+        "requesting_user": "user2"
+      }
     },
     "helper_images": {
       "ap-northeast-1": "ami-383c1956",
@@ -41,18 +50,23 @@
   },
   "azure": {
     "groups": {
-      "group1": ["azure-china", "azure"]
+      "group1": {
+        "accounts": ["azure-china", "azure"],
+        "requesting_user": "user1"
+      }
     },
     "accounts": {
       "azure-china": {
         "region": "China East",
         "resource_group": "cn_res_group",
+        "requesting_user": "user1",
         "container_name": "cncontainer1",
         "storage_account": "cnstorage1"
       },
-      "azure": {  
+      "azure": {
         "region": "East US 2",
         "resource_group": "res_group_2",
+        "requesting_user": "user1",
         "container_name": "container2",
         "storage_account": "storage2"
       }

--- a/test/data/accounts.json
+++ b/test/data/accounts.json
@@ -1,0 +1,33 @@
+{
+  "ec2": {
+    "regions": {
+      "aws": ["ap-northeast-1", "ap-northeast-2"],
+      "aws-us-gov": ["us-gov-west-1"]
+    },
+    "groups": {
+      "test": {
+        "accounts": ["test-aws-gov", "test-aws"],
+        "requesting_user": "user2"
+      },
+      "test1": {
+        "accounts": [],
+        "requesting_user": "user1"
+      }
+    },
+    "accounts": {
+      "test-aws-gov": {
+        "partition": "aws-us-gov",
+        "requesting_user": "user2"
+      },
+      "test-aws": {
+        "partition": "aws",
+        "requesting_user": "user2"
+      }
+    },
+    "helper_images": {
+      "ap-northeast-1": "ami-383c1956",
+      "ap-northeast-2": "ami-249b554a",
+      "us-gov-west-1": "ami-c2b5d7e1"
+    }
+  }
+}


### PR DESCRIPTION
This is needed to allow for account updates such as new credentials and to prevent group name overlap between different requesting users.