### PR TITLE
Add delete account handling to credentials.

### DIFF
--- a/mash/services/base_service.py
+++ b/mash/services/base_service.py
@@ -83,6 +83,7 @@ class BaseService(object):
         )
 
         self.add_account_key = 'add_account'
+        self.delete_account_key = 'delete_account'
 
         logging.basicConfig()
         self.log = logging.getLogger(self.__class__.__name__)


### PR DESCRIPTION
- Add and delete account messages will be handled in the listener queue.
- Attempt to delete file if it exists based on request.