### PR TITLE
Integrate encryption key rotation

### DIFF
--- a/mash/services/credentials/key_rotate.py
+++ b/mash/services/credentials/key_rotate.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of mash.
+#
+# mash is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mash is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mash.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import os
+
+from cryptography.fernet import Fernet, MultiFernet
+from mash.mash_exceptions import MashCredentialsException
+
+
+def rotate_key(credentials_directory, keys_file, log_callback):
+    """
+    create a new encryption key and rotate all credentials files.
+
+    Will attempt to rotate credentials files to the new key . If
+    any fail an exception is raised prior to return.
+    """
+    log_callback(
+        'Starting key rotation with keys file {0} in directory {1}.'.format(
+            keys_file, credentials_directory
+        )
+    )
+
+    success = True
+
+    # Create new key
+    new_key = Fernet.generate_key().decode()
+
+    # Write both keys to file, new key is first
+    with open(keys_file, 'r+') as f:
+        keys = [key.strip() for key in f.readlines()]
+        f.seek(0)
+        f.write('\n'.join([new_key] + keys))
+
+    fernet_keys = [Fernet(key) for key in keys]
+    fernet = MultiFernet(fernet_keys)
+
+    # Rotate all credentials files
+    for root, dirs, files in os.walk(credentials_directory):
+        for credentials_file in files:
+            path = os.path.join(root, credentials_file)
+
+            with open(path, 'r+b') as f:
+                credentials = f.read().strip()
+
+                try:
+                    credentials = fernet.rotate(credentials)
+                except Exception as error:
+                    log_callback(
+                        'Failed key rotation on credential file {0}.'.format(
+                            path
+                        ),
+                        success=False
+                    )
+                    success = False
+                else:
+                    f.seek(0)
+                    f.write(credentials)
+
+    if not success:
+        raise MashCredentialsException(
+            'All credentials files have not been rotated.'
+        )
+
+
+def clean_old_keys(keys_file, log_callback):
+    """
+    Purge old keys from encryption keys file.
+
+    If there's an error send a message to log callback.
+    """
+    try:
+        with open(keys_file, 'r+') as f:
+            f.readline()
+            f.truncate(f.tell())
+    except Exception as error:
+        log_callback(
+            'Unable to clean old keys from {0}: {1}.'.format(
+                keys_file, error
+            ),
+            success=False
+        )

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -38,20 +38,17 @@ class CredentialsService(BaseService):
     """
     def post_init(self):
         self.config = CredentialsConfig()
-
         self.set_logfile(self.config.get_log_file(self.service_exchange))
 
         self.services = self.config.get_service_names(
             credentials_required=True
         )
         self.encryption_keys_file = self.config.get_encryption_keys_file()
+        self.credentials_directory = self.config.get_credentials_dir()
+        self.jobs = {}
 
         if not os.path.exists(self.encryption_keys_file):
             self._create_encryption_keys_file()
-
-        self.credentials_directory = self.config.get_credentials_dir()
-
-        self.jobs = {}
 
         self.bind_queue(
             self.service_exchange, self.add_account_key, self.listener_queue

--- a/mash/services/credentials/service.py
+++ b/mash/services/credentials/service.py
@@ -19,6 +19,9 @@ import jwt
 import json
 import os
 
+from apscheduler import events
+from apscheduler.schedulers.background import BackgroundScheduler
+
 from contextlib import suppress
 from cryptography.fernet import Fernet
 from datetime import datetime, timedelta
@@ -26,6 +29,7 @@ from datetime import datetime, timedelta
 # project
 from mash.services.base_service import BaseService
 from mash.services.credentials.config import CredentialsConfig
+from mash.services.credentials.key_rotate import clean_old_keys, rotate_key
 
 
 class CredentialsService(BaseService):
@@ -56,6 +60,12 @@ class CredentialsService(BaseService):
             self.service_exchange, self.delete_account_key, self.listener_queue
         )
         self._bind_credential_request_keys()
+
+        self.scheduler = BackgroundScheduler()
+        self.scheduler.add_listener(
+            self._handle_key_rotation_result,
+            events.EVENT_JOB_EXECUTED | events.EVENT_JOB_ERROR
+        )
 
         self.restart_jobs(self._add_job)
         self.start()
@@ -268,6 +278,26 @@ class CredentialsService(BaseService):
 
         message.ack()
 
+    def _handle_key_rotation_result(self, event):
+        """
+        Callback when key rotation cron finishes.
+
+        If the rotation does not finish successfully the old key
+        is left in key file.
+
+        Once a successful rotation happens all old keys are purged.
+        """
+        if event.exception:
+            self.log.error(
+                'Key rotation did not finish successfully.'
+                ' Old key will remain in key file.'
+            )
+        else:
+            clean_old_keys(
+                self.encryption_keys_file, self._send_control_response
+            )
+            self.log.info('Key rotation finished.')
+
     def _publish_credentials_response(self, credentials_response, issuer):
         """
         Publish the encoded JWT with secrets to the calling service.
@@ -350,6 +380,25 @@ class CredentialsService(BaseService):
                 success=False
             )
 
+    def _start_rotation_job(self):
+        """
+        Schedule new key rotation cron job in background scheduler.
+
+        Job is run once a month on the first Saturday at 0000.
+        """
+        self.scheduler.add_job(
+            rotate_key,
+            'cron',
+            args=(
+                self.credentials_directory,
+                self.encryption_keys_file,
+                self._send_control_response
+            ),
+            day='1st sat,3rd sat',
+            hour='0',
+            minute='0'
+        )
+
     def _store_encrypted_credentials(
         self, account, credentials, provider, user
     ):
@@ -387,6 +436,9 @@ class CredentialsService(BaseService):
         """
         Start credentials service.
         """
+        self.scheduler.start()
+        self._start_rotation_job()
+
         self.consume_queue(self._handle_job_documents)
         self.consume_queue(
             self._handle_account_request, queue_name=self.listener_queue
@@ -410,5 +462,6 @@ class CredentialsService(BaseService):
 
         Stop consuming queues and close pika connections.
         """
+        self.scheduler.shutdown()
         self.channel.stop_consuming()
         self.close_connection()

--- a/test/unit/services/credentials/key_rotate_test.py
+++ b/test/unit/services/credentials/key_rotate_test.py
@@ -1,0 +1,71 @@
+import io
+import pytest
+import os
+
+from tempfile import TemporaryDirectory
+from unittest.mock import call, MagicMock, patch
+
+from mash.services.credentials.key_rotate import clean_old_keys, rotate_key
+from mash.mash_exceptions import MashCredentialsException
+
+
+def test_clean_old_keys():
+    log_callback = MagicMock()
+
+    with patch('builtins.open', create=True) as mock_open:
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle.readline.return_value = 'test-key123'
+        file_handle.truncate.side_effect = Exception('unable to remove keys')
+
+        clean_old_keys('/tmp/keys.file', log_callback)
+
+    log_callback.assert_called_once_with(
+        'Unable to clean old keys from /tmp/keys.file:'
+        ' unable to remove keys.',
+        success=False
+    )
+
+
+def test_rotate_key():
+    with TemporaryDirectory() as test_dir:
+        creds_dir = os.path.join(test_dir, 'creds')
+        keys_file = os.path.join(test_dir, 'keys.file')
+
+        os.makedirs(creds_dir)
+
+        with open(keys_file, 'w') as f:
+            f.write('XxgkVrKyG9gZqdvbycZgaSZF1Ro0Vr8DBMXjBuc4uRo=')
+
+        # Create an empty invalid cred file
+        open(os.path.join(creds_dir, 'invalid.creds'), 'a').close()
+
+        # Create a valid cred file
+        with open(os.path.join(creds_dir, 'valid.creds'), 'w') as cred_file:
+            cred_file.write(
+                'gAAAAABbFapolPqpWrLf5rpEj2xyFLkXlwclSQH-_t3tuJnACyRvOxLdw9qR'
+                '3kKMBlz3XIrGH9GJdiA9IJl9y_iQLeCfIAM_4ckDMcYHMLe0WWNnsn4zj9E='
+            )
+
+        log_callback = MagicMock()
+
+        with pytest.raises(MashCredentialsException) as error:
+            rotate_key(creds_dir, keys_file, log_callback)
+
+        assert str(error.value) == \
+            'All credentials files have not been rotated.'
+
+        log_callback.assert_has_calls([
+            call(
+                'Starting key rotation with keys file {0} '
+                'in directory {1}.'.format(
+                    keys_file, creds_dir
+                )
+            ),
+            call(
+                'Failed key rotation on credential file {0}.'.format(
+                    os.path.join(creds_dir, 'invalid.creds')
+                ),
+                success=False
+            )
+        ]),


### PR DESCRIPTION
- The keys will be rotated buy a cron job running in background
scheduler.
- Rotation will occur every other week at 0000 on Sat.
- If there is an error with any credentials files the old keys
will remain in keys file.
- Once a successful rotation occurs all old keys are purged
leaving one encryption key.