### PR TITLE
Move static EC2 info to the yaml config.

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -19,3 +19,48 @@ jobcreator:
   accounts_file: /etc/mash/accounts.json
 obs:
   download_directory: /var/tmp/mash/images
+provider:
+  ec2:
+    regions:
+      aws:
+        - ap-northeast-1
+        - ap-northeast-2
+        - ap-northeast-3
+        - ap-south-1
+        - ap-southeast-1
+        - ap-southeast-2
+        - ca-central-1
+        - eu-central-1
+        - eu-west-1
+        - eu-west-2
+        - eu-west-3
+        - sa-east-1
+        - us-east-1
+        - us-east-2
+        - us-west-1
+        - us-west-2
+      aws-cn:
+        - cn-north-1
+        - cn-northwest-1
+      aws-us-gov:
+        - us-gov-west-1
+    helper_images:
+      ap-northeast-1: ami-383c1956
+      ap-northeast-2: ami-249b554a
+      ap-northeast-3: ami-82444aff
+      ap-southeast-1: ami-c9b572aa
+      ap-southeast-2: ami-48d38c2b
+      ap-south-1: ami-a6d1bac9
+      ca-central-1: ami-21d76545
+      cn-north-1: ami-bcc45885
+      cn-northwest-1: ami-23978241
+      eu-central-1: ami-bc5b48d0
+      eu-west-1: ami-bff32ccc
+      eu-west-2: ami-2a676d4
+      eu-west-3: ami-7bc17406
+      sa-east-1: ami-6817af04
+      us-east-1: ami-4b814f22
+      us-east-2: ami-71ca9114
+      us-gov-west-1: ami-c2b5d7e1
+      us-west-1: ami-d5ea86b5
+      us-west-2: ami-f0091d9

--- a/examples/accounts.json
+++ b/examples/accounts.json
@@ -1,19 +1,9 @@
 {
   "ec2": {
-    "regions": {
-      "aws": [
-        "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1",
-        "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1",
-        "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-1",
-        "us-east-2", "us-west-1", "us-west-2"
-      ],
-      "aws-cn": ["cn-north-1", "cn-northwest-1"],
-      "aws-us-gov": ["us-gov-west-1"]
-    },
     "groups": {
       "GROUP_ONE": {
         "accounts": ["ACCOUNT_ONE", "ACCOUNT_TWO"],
-        "requesting_user": "user1"
+        "requesting_user": "user2"
       }
     },
     "accounts": {
@@ -25,27 +15,6 @@
         "partition": "aws",
         "requesting_user": "user2"
       }
-    },
-    "helper_images": {
-      "ap-northeast-1": "ami-383c1956",
-      "ap-northeast-2": "ami-249b554a",
-      "ap-northeast-3": "ami-82444aff",
-      "ap-southeast-1": "ami-c9b572aa",
-      "ap-southeast-2": "ami-48d38c2b",
-      "ap-south-1": "ami-a6d1bac9",
-      "ca-central-1": "ami-21d76545",
-      "cn-north-1": "ami-bcc45885",
-      "cn-northwest-1": "ami-23978241",
-      "eu-central-1": "ami-bc5b48d0",
-      "eu-west-1": "ami-bff32ccc",
-      "eu-west-2": "ami-2a676d4",
-      "eu-west-3": "ami-7bc17406",
-      "sa-east-1": "ami-6817af04",
-      "us-east-1": "ami-4b814f22",
-      "us-east-2": "ami-71ca9114",
-      "us-gov-west-1": "ami-c2b5d7e1",
-      "us-west-1": "ami-d5ea86b5",
-      "us-west-2": "ami-f0091d91"
     }
   },
   "azure": {

--- a/mash/services/base_config.py
+++ b/mash/services/base_config.py
@@ -102,6 +102,19 @@ class BaseConfig(object):
             dir=log_dir, service=service
         )
 
+    def get_provider_data(self):
+        """
+        Return the provider data from config.
+        """
+        data = self._get_attribute(attribute='provider')
+
+        if not data:
+            raise MashConfigException(
+                'Provider data must be provided in config file.'
+            )
+
+        return data
+
     def get_service_names(self, credentials_required=False):
         """
         Return a list of all service names.

--- a/mash/services/jobcreator/__init__.py
+++ b/mash/services/jobcreator/__init__.py
@@ -27,9 +27,10 @@ from mash.services.jobcreator import schema
 from mash.services.jobcreator.ec2_job import EC2Job
 
 
-def create_job(job_doc, accounts_info):
+def create_job(job_doc, accounts_info, provider_data):
     csp_name = job_doc.get('provider')
     accounts_info = accounts_info.get(csp_name)
+    provider_data = provider_data.get(csp_name)
 
     if csp_name == CSP.ec2:
         job_class = EC2Job
@@ -46,4 +47,4 @@ def create_job(job_doc, accounts_info):
     except Exception as error:
         raise MashValidationException(error)
     else:
-        return job_class(accounts_info, **job_doc)
+        return job_class(accounts_info, provider_data, **job_doc)

--- a/mash/services/jobcreator/base_job.py
+++ b/mash/services/jobcreator/base_job.py
@@ -27,7 +27,7 @@ class BaseJob(object):
     Handles incoming job requests.
     """
     def __init__(
-            self, accounts_info, provider, provider_accounts,
+            self, accounts_info, provider_data, provider, provider_accounts,
             provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, old_cloud_image_name, project,
             image_description, distro, tests,
@@ -35,6 +35,7 @@ class BaseJob(object):
     ):
         self.id = str(uuid.uuid4())
         self.accounts_info = accounts_info
+        self.provider_data = provider_data
         self.provider = provider
         self.provider_accounts = provider_accounts
         self.provider_groups = provider_groups

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -29,8 +29,8 @@ class EC2Job(BaseJob):
     Handles incoming job requests.
     """
     def __init__(
-            self, accounts_info, provider, provider_accounts, provider_groups,
-            requesting_user, last_service, utctime, image,
+            self, accounts_info, provider_data, provider, provider_accounts,
+            provider_groups, requesting_user, last_service, utctime, image,
             cloud_image_name, old_cloud_image_name, project,
             share_with, allow_copy, image_description, distro,
             tests, conditions=None, instance_type=None
@@ -40,10 +40,10 @@ class EC2Job(BaseJob):
         self.target_account_info = {}
 
         super(EC2Job, self).__init__(
-            accounts_info, provider, provider_accounts, provider_groups,
-            requesting_user, last_service, utctime, image, cloud_image_name,
-            old_cloud_image_name, project, image_description, distro, tests,
-            conditions, instance_type
+            accounts_info, provider_data, provider, provider_accounts,
+            provider_groups, requesting_user, last_service, utctime, image,
+            cloud_image_name, old_cloud_image_name, project,
+            image_description, distro, tests, conditions, instance_type
         )
 
     def _get_account_info(self):
@@ -71,7 +71,7 @@ class EC2Job(BaseJob):
             accounts[provider_account['name']] = \
                 provider_account['target_regions']
 
-        helper_images = self.accounts_info.get('helper_images')
+        helper_images = self.provider_data.get('helper_images')
 
         # Get all accounts from all groups
         for group in self.provider_groups:
@@ -100,7 +100,7 @@ class EC2Job(BaseJob):
         Return a list of regions based on account name.
         """
         regions_key = self.accounts_info['accounts'][account]['partition']
-        return self.accounts_info['regions'][regions_key]
+        return self.provider_data['regions'][regions_key]
 
     def _get_target_regions_list(self):
         """

--- a/mash/services/jobcreator/service.py
+++ b/mash/services/jobcreator/service.py
@@ -39,6 +39,7 @@ class JobCreatorService(BaseService):
         self.config = JobCreatorConfig()
         self.set_logfile(self.config.get_log_file(self.service_exchange))
         self.accounts_file = self.config.get_accounts_file()
+        self.provider_data = self.config.get_provider_data()
         self.services = self.config.get_service_names()
 
         if not os.path.exists(self.accounts_file):
@@ -97,7 +98,7 @@ class JobCreatorService(BaseService):
         Split args and send messages to all services to initiate job.
         """
         accounts_info = self._get_accounts_from_file()
-        job = create_job(job_doc, accounts_info)
+        job = create_job(job_doc, accounts_info, self.provider_data)
 
         self.log.info(
             'Started a new job: {0}'.format(json.dumps(job_doc, indent=2)),

--- a/test/data/accounts.json
+++ b/test/data/accounts.json
@@ -1,9 +1,5 @@
 {
   "ec2": {
-    "regions": {
-      "aws": ["ap-northeast-1", "ap-northeast-2"],
-      "aws-us-gov": ["us-gov-west-1"]
-    },
     "groups": {
       "test": {
         "accounts": ["test-aws-gov", "test-aws"],
@@ -23,11 +19,6 @@
         "partition": "aws",
         "requesting_user": "user2"
       }
-    },
-    "helper_images": {
-      "ap-northeast-1": "ami-383c1956",
-      "ap-northeast-2": "ami-249b554a",
-      "us-gov-west-1": "ami-c2b5d7e1"
     }
   }
 }

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -11,3 +11,18 @@ services:
   - pint
 non_cred_services:
   - obs
+provider:
+  ec2:
+    regions:
+      aws:
+        - ap-northeast-1
+        - ap-northeast-2
+      aws-cn:
+        - cn-north-1
+      aws-us-gov:
+        - us-gov-west-1
+    helper_images:
+      ap-northeast-1: ami-383c1956
+      ap-northeast-2: ami-249b554a
+      cn-north-1: ami-bcc45885
+      us-gov-west-1: ami-c2b5d7e1

--- a/test/unit/services/base/config_test.py
+++ b/test/unit/services/base/config_test.py
@@ -27,6 +27,17 @@ class TestBaseConfig(object):
 
         assert msg == str(error.value)
 
+    def test_get_provider_data(self):
+        data = self.config.get_provider_data()
+        assert data['ec2']['regions']['aws-cn'] == ['cn-north-1']
+        assert data['ec2']['helper_images']['cn-north-1'] == 'ami-bcc45885'
+
+        with raises(MashConfigException) as error:
+            self.empty_config.get_provider_data()
+
+        assert str(error.value) == \
+            'Provider data must be provided in config file.'
+
     def test_get_services_names(self):
         # Services requiring credentials
         expected = [

--- a/test/unit/services/jobcreator/factory_test.py
+++ b/test/unit/services/jobcreator/factory_test.py
@@ -12,7 +12,7 @@ from mash.services.jobcreator import create_job
 def test_job_creator_create_job(mock_validate):
     # invalid provider
     with raises(MashJobCreatorException) as error:
-        create_job({'provider': 'fake'}, {})
+        create_job({'provider': 'fake'}, {}, {})
 
     assert str(error.value) == \
         'Support for fake Cloud Service not implemented'
@@ -23,7 +23,7 @@ def test_job_creator_create_job(mock_validate):
 
     # invalid job doc
     with raises(MashValidationException) as error:
-        create_job({'provider': 'ec2'}, {'ec2': {}})
+        create_job({'provider': 'ec2'}, {}, {'ec2': {}})
 
     assert str(error.value) == \
         'Validation failed for provided job doc.'

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -90,6 +90,21 @@ class TestJobCreatorService(object):
     def test_jobcreator_handle_service_message(
             self, mock_publish, mock_uuid, mock_random
     ):
+        self.jobcreator.provider_data = {
+            'ec2': {
+                'regions': {
+                    'aws': ['ap-northeast-1', 'ap-northeast-2'],
+                    'aws-cn': ['cn-north-1'],
+                    'aws-us-gov': ['us-gov-west-1']
+                },
+                'helper_images': {
+                    'ap-northeast-1': 'ami-383c1956',
+                    'ap-northeast-2': 'ami-249b554a',
+                    'cn-north-1': 'ami-bcc45885',
+                    'us-gov-west-1': 'ami-c2b5d7e1'
+                }
+            }
+        }
         message = MagicMock()
 
         uuid_val = '12345678-1234-1234-1234-123456789012'


### PR DESCRIPTION
Step 1: Move the ec2 region info to yaml config. 

- I think this is okay staying in the job creator since it's not really account specific.
- The job classes will handle this data the same way.
- Also made the "provider" generic in case there is a need for GCE or Azure info. This way it can be handled generically in factory method.

Fixes #235