### PR TITLE
Allow obs api_url to be specified in job

### DIFF
--- a/mash/services/obs/defaults.py
+++ b/mash/services/obs/defaults.py
@@ -21,6 +21,9 @@ class Defaults(object):
     """
     Default values
     """
+    @classmethod
+    def get_api_url(self):
+        return 'https://api.opensuse.org'
 
     @classmethod
     def get_download_dir(self):

--- a/mash/services/obs/service.py
+++ b/mash/services/obs/service.py
@@ -24,6 +24,7 @@ from mash.services.base_service import BaseService
 from mash.services.obs.build_result import OBSImageBuildResult
 from mash.services.obs.config import OBSConfig
 from mash.utils.json_format import JsonFormat
+from mash.services.obs.defaults import Defaults
 
 
 class OBSImageBuildResultService(BaseService):
@@ -128,6 +129,7 @@ class OBSImageBuildResultService(BaseService):
         {
           "obs_job": {
               "id": "123",
+              "api_url": "https://api.opensuse.org",
               "project": "Virtualization:Appliances:Images:Testing_x86",
               "image": "test-image-oem",
               "utctime": "now|always|timestring_utc_timezone",
@@ -198,6 +200,7 @@ class OBSImageBuildResultService(BaseService):
             job_id=job_id, job_file=job['job_file'],
             project=job['project'], package=job['image'],
             conditions=job['conditions'],
+            api_url=job.get('api_url') or Defaults.get_api_url(),
             download_directory=self.download_directory
         )
         job_worker.set_log_handler(self._send_job_response)

--- a/test/unit/services/obs/service_test.py
+++ b/test/unit/services/obs/service_test.py
@@ -110,12 +110,14 @@ class TestOBSImageBuildResultService(object):
         message.method = {'routing_key': 'job_document'}
         message.body = '{"obs_job":{"id": "4711","project": ' + \
             '"Virtualization:Appliances:Images:Testing_x86","image": ' + \
-            '"test-image-docker","utctime": "always"}}'
+            '"test-image-docker","utctime": ' + \
+            '"always","api_url": "https://api.opensuse.org"}}'
         self.obs_result._process_message(message)
         message.ack.assert_called_once_with()
         mock_add_job.assert_called_once_with(
             {
                 'obs_job': {
+                    'api_url': 'https://api.opensuse.org',
                     'project': 'Virtualization:Appliances:Images:Testing_x86',
                     'image': 'test-image-docker',
                     'id': '4711',
@@ -160,6 +162,7 @@ class TestOBSImageBuildResultService(object):
         job_data = {
             "obs_job": {
                 "id": "123",
+                "api_url": "https://api.opensuse.org",
                 "project": "Virtualization:Appliances:Images:Testing_x86",
                 "image": "test-image-oem",
                 "utctime": "now",
@@ -202,6 +205,7 @@ class TestOBSImageBuildResultService(object):
         data = {
             "id": "123",
             "job_file": "tempfile",
+            "api_url": "https://api.opensuse.org",
             "project": "Virtualization:Appliances:Images:Testing_x86",
             "image": "test-image-oem",
             "utctime": "now",


### PR DESCRIPTION
The project path in an obs job was always set to the
default opensuse build service server. However the
project could also be hosted on another server which
would require the api_url to be specified in the
obs job document. This patch allows to optionally
provide this information