### PR TITLE
Simplify listener message handling.

### DIFF
--- a/mash/services/mash_job.py
+++ b/mash/services/mash_job.py
@@ -19,7 +19,7 @@
 import logging
 
 from mash.mash_exceptions import MashJobException
-from mash.services.status_levels import UNKOWN, SUCCESS
+from mash.services.status_levels import UNKOWN
 from mash.utils.mash_utils import handle_request
 
 
@@ -165,13 +165,7 @@ class MashJob(object):
 
     def get_status_message(self):
         """Status message property."""
-        if self.status == SUCCESS:
-            return self.status_msg
-        else:
-            return {
-                'id': self.id,
-                'status': self.status,
-            }
+        return self.status_msg
 
     def set_status_message(self, message):
         """

--- a/test/unit/services/base/job_test.py
+++ b/test/unit/services/base/job_test.py
@@ -112,11 +112,6 @@ class TestMashJob(object):
 
     def test_get_set_status_message(self):
         job = MashJob(self.job_config, self.config)
-        status_msg = job.get_status_message()
-
-        assert status_msg['id'] == '1'
-        assert status_msg['status'] is None
-
         job.set_status_message({'id': '1', 'status': 'success'})
         status_msg = job.get_status_message()
 


### PR DESCRIPTION
Always return the entire status msg for a job no matter the
status. And always set the status msg from the previous service
no matter the status. This allows any data and errors added to
the status to propogate until the job finishes.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
