### PR TITLE
Cleanup unused share snapshot arg.

### DIFF
--- a/mash/services/api/schema/jobs/ec2.py
+++ b/mash/services/api/schema/jobs/ec2.py
@@ -121,14 +121,6 @@ ec2_job_message['properties']['skip_replication'] = {
                    'the image that is uploaded will not be replicated'
                    'to any regions.'
 }
-ec2_job_message['properties']['share_snapshot_with'] = {
-    'type': 'string',
-    'format': 'regex',
-    'pattern': '^[0-9]{12}(,[0-9]{12})*$',
-    'example': '123456789012,098765432109',
-    'description': 'A comma-separated list of accounts to share the '
-                   'image snapshot with.'
-}
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},


### PR DESCRIPTION
EC2 jobs do not use share_snapshot_with as share_with and
allow_copy already covered the functionality from ec2imgutils.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
