### PR TITLE
Set a prefix for img-proof tests.

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -26,7 +26,7 @@ APScheduler
 python-dateutil>=2.6.0,<2.8.1
 amqpstorm
 ec2imgutils>=8.1.2
-img-proof>=5.2.0
+img-proof>=6.0.0
 lxml
 requests
 urllib3<1.25,>=1.20

--- a/mash/services/test/img_proof_helper.py
+++ b/mash/services/test/img_proof_helper.py
@@ -64,7 +64,8 @@ def img_proof_test(
         timeout=img_proof_timeout,
         enable_secure_boot=enable_secure_boot,
         image_project=image_project,
-        log_callback=log_callback
+        log_callback=log_callback,
+        prefix_name='mash'
     )
 
     status = SUCCESS if status == 0 else FAILED

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -42,8 +42,8 @@ BuildRequires:  python3-APScheduler >= 3.3.1
 BuildRequires:  python3-python-dateutil >= 2.6.0
 BuildRequires:  python3-python-dateutil < 2.8.1
 BuildRequires:  python3-ec2imgutils >= 8.1.2
-BuildRequires:  python3-img-proof >= 5.2.0
-BuildRequires:  python3-img-proof-tests >= 5.2.0
+BuildRequires:  python3-img-proof >= 6.0.0
+BuildRequires:  python3-img-proof-tests >= 6.0.0
 BuildRequires:  python3-lxml
 BuildRequires:  python3-Flask
 BuildRequires:  python3-flask-restplus
@@ -70,8 +70,8 @@ Requires:       python3-APScheduler >= 3.3.1
 Requires:       python3-python-dateutil >= 2.6.0
 Requires:       python3-python-dateutil < 2.8.1
 Requires:       python3-ec2imgutils >= 8.1.2
-Requires:       python3-img-proof >= 5.2.0
-Requires:       python3-img-proof-tests >= 5.2.0
+Requires:       python3-img-proof >= 6.0.0
+Requires:       python3-img-proof-tests >= 6.0.0
 Requires:       python3-lxml
 Requires:       python3-Flask
 Requires:       python3-flask-restplus

--- a/test/unit/services/test/azure_job_test.py
+++ b/test/unit/services/test/azure_job_test.py
@@ -105,7 +105,8 @@ class TestAzureTestJob(object):
             timeout=None,
             enable_secure_boot=False,
             image_project=None,
-            log_callback=job._log_callback
+            log_callback=job._log_callback,
+            prefix_name='mash'
         )
         job._log_callback.info.reset_mock()
 

--- a/test/unit/services/test/ec2_job_test.py
+++ b/test/unit/services/test/ec2_job_test.py
@@ -116,7 +116,8 @@ class TestEC2TestJob(object):
             timeout=None,
             enable_secure_boot=False,
             image_project=None,
-            log_callback=job._log_callback
+            log_callback=job._log_callback,
+            prefix_name='mash'
         )
         client.delete_key_pair.assert_called_once_with(KeyName='random_name')
         mock_cleanup_image.assert_called_once_with(

--- a/test/unit/services/test/gce_job_test.py
+++ b/test/unit/services/test/gce_job_test.py
@@ -114,7 +114,8 @@ class TestGCETestJob(object):
                 timeout=None,
                 enable_secure_boot=True,
                 image_project=None,
-                log_callback=job._log_callback
+                log_callback=job._log_callback,
+                prefix_name='mash'
             )
         ])
         job._log_callback.warning.reset_mock()
@@ -193,7 +194,8 @@ class TestGCETestJob(object):
                 timeout=None,
                 enable_secure_boot=True,
                 image_project=None,
-                log_callback=job._log_callback
+                log_callback=job._log_callback,
+                prefix_name='mash'
             ),
             call(
                 'gce',
@@ -222,7 +224,8 @@ class TestGCETestJob(object):
                 timeout=None,
                 enable_secure_boot=True,
                 image_project=None,
-                log_callback=job._log_callback
+                log_callback=job._log_callback,
+                prefix_name='mash'
             )
         ])
 

--- a/test/unit/services/test/oci_job_test.py
+++ b/test/unit/services/test/oci_job_test.py
@@ -104,7 +104,8 @@ class TestOCITestJob(object):
             timeout=600,
             enable_secure_boot=False,
             image_project=None,
-            log_callback=job._log_callback
+            log_callback=job._log_callback,
+            prefix_name='mash'
         )
         job._log_callback.info.reset_mock()
 


### PR DESCRIPTION
All instances launched using img-proof will have a prefix of mash
to help with tracking instances that get left behind.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
