### PR TITLE
Improves instance selection variables to improve code legibility

### DIFF
--- a/config/mash_config.yaml
+++ b/config/mash_config.yaml
@@ -92,7 +92,7 @@ cloud:
     - region: us-east-1
       partition: aws
       arch: x86_64
-      instance_names:
+      instance_types:
       - c5.large
       - m5.large
       - t3.small
@@ -103,7 +103,7 @@ cloud:
     - region: us-east-1
       arch: x86_64
       partition: aws
-      instance_names:
+      instance_types:
       - i3.large
       - t2.small
       boot_types:
@@ -112,7 +112,7 @@ cloud:
     - region: us-east-2
       partition: aws
       arch: x86_64
-      instance_names:
+      instance_types:
       - m6a.large
       - c6a.large
       - r6a.large
@@ -124,7 +124,7 @@ cloud:
     - region: us-east-1
       partition: aws
       arch: aarch64
-      instance_names:
+      instance_types:
       - t4g.small
       - m6g.medium
       boot_types:
@@ -134,7 +134,7 @@ cloud:
     - region: cn-north-1
       partition: aws-cn
       arch: x86_64
-      instance_names:
+      instance_types:
       - t3.small
       boot_types:
         - bios
@@ -142,7 +142,7 @@ cloud:
     - region: cn-north-1
       partition: aws-cn
       arch: x86_64
-      instance_names:
+      instance_types:
       - m5.large
       - t3.small
       boot_types:
@@ -152,7 +152,7 @@ cloud:
     - region: cn-north-1
       partition: aws-cn
       arch: aarch64
-      instance_names:
+      instance_types:
       - t4g.small
       boot_types:
       - uefi
@@ -161,7 +161,7 @@ cloud:
     - region: us-gov-east-1
       partition: aws-us-gov
       arch: x86_64
-      instance_names:
+      instance_types:
       - i3.large
       - t3.small
       boot_types:
@@ -170,7 +170,7 @@ cloud:
     - region: us-gov-east-1
       partition: aws-us-gov
       arch: x86_64
-      instance_names:
+      instance_types:
       - c5.large
       - m5.large
       - t3.small
@@ -181,7 +181,7 @@ cloud:
     - region: us-gov-east-1
       partition: aws-us-gov
       arch: aarch64
-      instance_names:
+      instance_types:
       - t4g.small
       boot_types:
       - uefi

--- a/doc/static/ec2_test_strategy_improvement.md
+++ b/doc/static/ec2_test_strategy_improvement.md
@@ -37,7 +37,7 @@ cloud:
     - region: us-east-1
       partition: aws
       arch: x86_64
-      instance_names:
+      instance_types:
       - c5.large
       - m5.large
       - t3.small
@@ -48,7 +48,7 @@ cloud:
     - region: us-east-1
       arch: x86_64
       partition: aws
-      instance_names:
+      instance_types:
       - i3.large
       - t2.small
       boot_types:
@@ -57,7 +57,7 @@ cloud:
     - region: us-east-2
       partition: aws
       arch: x86_64
-      instance_names:
+      instance_types:
       - m6a.large
       - c6a.large
       - r6a.large
@@ -101,7 +101,7 @@ The following settings are required for each instance group:
  selected.
  - *partition*: AWS partition
  - *arch*: instance architecture (x86_64 or aarch64)
- - *instance_names*: name of the instance types. One of these will be selected
+ - *instance_types*: list of the instance types. One of these will be selected
  randomly if this group is selected.
  - *boot_types*: which boot types do these isntance types support
  (bios/uefi/uefi-preferred).

--- a/mash/services/test/ec2_test_utils.py
+++ b/mash/services/test/ec2_test_utils.py
@@ -91,33 +91,34 @@ def remove_incompatible_feature_combinations(feature_combinations):
     return feature_combinations
 
 
-def select_instances_for_tests(
+def select_instance_configs_for_tests(
     test_regions: list,
     instance_catalog: list,
     feature_combinations: list,
     logger: logging.Logger = None
 ) -> list:
     """
-    Selects the instance types and configurations used in the tests
+    Selects the instance configurations used in the tests
     Taking as input the instance catalog configured and the
     feature_combinations that are required to be tested, chooses some intances
     to cover the provided feature combinations.
     Raises a MashTestException if there's some feature_combination that is not
     possible to test with the instance_catalog.
     """
-    instances = []
+    instance_configs = []
     for feature_combination in feature_combinations:
-        instance = select_instance_for_feature_combination(
+        instance_config = select_instance_config_for_feature_combination(
             test_regions=test_regions,
             feature_combination=feature_combination,
             instance_catalog=instance_catalog,
             logger=logger
         )
-        if instance:
-            instances.append(instance)
+        if instance_config:
+            instance_configs.append(instance_config)
             if logger:
                 logger.debug(
-                    f'Selected instance {instance} for {feature_combination}'
+                    f'Selected instance {instance_config} for '
+                    f'{feature_combination}'
                 )
         else:
             # Just writing in the log the issue for now
@@ -127,10 +128,10 @@ def select_instances_for_tests(
             )
             if logger:
                 logger.error(msg)
-    return instances
+    return instance_configs
 
 
-def select_instance_for_feature_combination(
+def select_instance_config_for_feature_combination(
     test_regions: list,
     feature_combination: tuple,
     instance_catalog: list,
@@ -169,18 +170,18 @@ def select_instance_for_feature_combination(
             continue
         candidate_groups.append(instance_group)
 
-    instance = None
+    instance_config = None
     if candidate_groups:
         selected_group = random.choice(candidate_groups)
-        instance = {
+        instance_config = {
             'arch': arch,
-            'instance_name': random.choice(selected_group['instance_names']),
+            'instance_type': random.choice(selected_group['instance_types']),
             'boot_type': boot_type,
             'cpu_option': cpu_option,
             'region': selected_group['region'],
             'partition': selected_group['partition']
         }
-    return instance
+    return instance_config
 
 
 def get_partition_test_regions(test_regions: dict):

--- a/test/data/mash_config.yaml
+++ b/test/data/mash_config.yaml
@@ -44,7 +44,7 @@ cloud:
     test_instance_catalog:
     - region: us-east-1
       arch: x86_64
-      instance_names:
+      instance_types:
       - c5.large
       - m5.large
       - t3.small
@@ -54,7 +54,7 @@ cloud:
       cpu_options: []
     - region: us-east-1
       arch: x86_64
-      instance_names:
+      instance_types:
       - i3.large
       - t2.small
       boot_types:
@@ -62,7 +62,7 @@ cloud:
       cpu_options: []
     - region: us-east-2
       arch: x86_64
-      instance_names:
+      instance_types:
       - m6a.large
       - c6a.large
       - r6a.large
@@ -73,7 +73,7 @@ cloud:
       - AmdSevSnp_enabled
     - region: us-east-1
       arch: aarch64
-      instance_names:
+      instance_types:
       - t4g.small
       - m6g.medium
       boot_types: []

--- a/test/unit/services/test/config_test.py
+++ b/test/unit/services/test/config_test.py
@@ -18,7 +18,7 @@ class TestTestConfig(object):
             {
                 "region": "us-east-1",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "c5.large",
                     "m5.large",
                     "t3.small"
@@ -32,7 +32,7 @@ class TestTestConfig(object):
             {
                 "region": "us-east-1",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "i3.large",
                     "t2.small"
                 ],
@@ -44,7 +44,7 @@ class TestTestConfig(object):
             {
                 "region": "us-east-2",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "m6a.large",
                     "c6a.large",
                     "r6a.large"
@@ -60,7 +60,7 @@ class TestTestConfig(object):
             {
                 "region": "us-east-1",
                 "arch": "aarch64",
-                "instance_names": [
+                "instance_types": [
                     "t4g.small",
                     "m6g.medium"
                 ],

--- a/test/unit/services/test/ec2_job_test.py
+++ b/test/unit/services/test/ec2_job_test.py
@@ -39,7 +39,7 @@ class TestEC2TestJob(object):
             {
                 "region": "us-east-2",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "m6a.large"
                 ],
                 "boot_types": [
@@ -52,7 +52,7 @@ class TestEC2TestJob(object):
             {
                 "region": "us-east-2",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "m6a.large"
                 ],
                 "boot_types": [
@@ -67,7 +67,7 @@ class TestEC2TestJob(object):
             {
                 "region": "us-east-1",
                 "arch": "aarch64",
-                "instance_names": [
+                "instance_types": [
                     "t4g.small",
                     "m6g.medium"
                 ],

--- a/test/unit/services/test/ec2_test_utils_test.py
+++ b/test/unit/services/test/ec2_test_utils_test.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 from mash.services.test.ec2_test_utils import (
     get_instance_feature_combinations,
-    select_instances_for_tests,
+    select_instance_configs_for_tests,
     get_partition_test_regions,
     get_image_id_for_region,
     get_cpu_options
@@ -49,15 +49,15 @@ class TestEC2TestUtils(object):
                     cpu_options=cpu_options
                 ))
 
-    def test_select_instances_for_tests(self):
-        """tests the select_instances_for_tests"""
+    def test_select_instance_configs_for_tests(self):
+        """tests the select_instance_configs_for_tests"""
 
         instance_catalog = [
             {
                 "region": "us-east-1",
                 "partition": "aws",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                         "c5.large"
                 ],
                 "boot_types": [
@@ -70,7 +70,7 @@ class TestEC2TestUtils(object):
                 "region": "us-east-1",
                 "partition": "aws",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "i3.large"
                 ],
                 "boot_types": [
@@ -82,7 +82,7 @@ class TestEC2TestUtils(object):
                 "region": "us-east-2",
                 "partition": "aws",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "m6a.large"
                 ],
                 "boot_types": [
@@ -97,7 +97,7 @@ class TestEC2TestUtils(object):
                 "region": "us-east-1",
                 "partition": "aws",
                 "arch": "aarch64",
-                "instance_names": [
+                "instance_types": [
                     "t4g.small",
                     "m6g.medium"
                 ],
@@ -108,7 +108,7 @@ class TestEC2TestUtils(object):
                 "region": "us-gov-west-1",
                 "partition": "us-gov",
                 "arch": "x86_64",
-                "instance_names": [
+                "instance_types": [
                     "t4g.small",
                     "m6g.medium"
                 ],
@@ -128,7 +128,7 @@ class TestEC2TestUtils(object):
                     {
                         'region': 'us-east-1',
                         'partition': 'aws',
-                        'instance_name': 'i3.large',
+                        'instance_type': 'i3.large',
                         'boot_type': 'bios',
                         'cpu_option': 'AmdSevSnp_disabled',
                         'arch': 'x86_64'
@@ -145,14 +145,14 @@ class TestEC2TestUtils(object):
                     {
                         'region': 'us-east-1',
                         'partition': 'aws',
-                        'instance_name': 'i3.large',
+                        'instance_type': 'i3.large',
                         'boot_type': 'bios',
                         'cpu_option': 'AmdSevSnp_disabled',
                         'arch': 'x86_64'
                     },
                     {
                         'region': 'us-east-2',
-                        'instance_name': 'm6a.large',
+                        'instance_type': 'm6a.large',
                         'partition': 'aws',
                         'boot_type': 'uefi-preferred',
                         'cpu_option': 'AmdSevSnp_enabled',
@@ -167,7 +167,7 @@ class TestEC2TestUtils(object):
             test_regions,
             expected_instances
         ) in test_cases:
-            selected_instances = select_instances_for_tests(
+            selected_instances = select_instance_configs_for_tests(
                 test_regions=test_regions,
                 feature_combinations=feature_combinations,
                 instance_catalog=instance_catalog,
@@ -187,7 +187,7 @@ class TestEC2TestUtils(object):
             'Unable to find instance to test this feature combination: '
             f'{feature_combination}'
         )
-        instance_types = select_instances_for_tests(
+        instance_types = select_instance_configs_for_tests(
             test_regions=['us-gov-west-1'],
             feature_combinations=[feature_combination],
             instance_catalog=instance_catalog,


### PR DESCRIPTION
### What does this PR do? Why are we making this change?

This PR changes the name of some variables and functions for EC2 tests. The goal is to have better self describing variables and fns as we are using those to get an `instance_config`  (the configuration for the instance for some specific test) rather than just the instance type.

### How will these changes be tested?
Tests will be executed in a local mash instance with personal cloud accounts.

