### PR TITLE
Modifies the get_additional_tests_for_instance params

### DIFF
--- a/mash/services/test/gce_test_utils.py
+++ b/mash/services/test/gce_test_utils.py
@@ -255,21 +255,19 @@ def select_instance_config_for_feature_combination(
 
 
 def get_additional_tests_for_instance(
-    feature_combination,
+    arch,
+    boot_type,
+    shielded_vm,
+    nic,
+    confidential_compute,
     additional_tests
 ):
     """Provides a list of additional tests configured for each instance type"""
     tests = []
 
-    arch = feature_combination[0]
-    boot_type = feature_combination[1]
-    shielded_vm = feature_combination[2]
-    nic = feature_combination[3]
-    conf_compute = feature_combination[4]
-
     tests.extend(additional_tests.get(arch, []))
     tests.extend(additional_tests.get(boot_type, []))
     tests.extend(additional_tests.get(shielded_vm, []))
     tests.extend(additional_tests.get(nic, []))
-    tests.extend(additional_tests.get(conf_compute, []))
+    tests.extend(additional_tests.get(confidential_compute, []))
     return tests

--- a/test/unit/services/test/gce_test_utils_test.py
+++ b/test/unit/services/test/gce_test_utils_test.py
@@ -385,8 +385,17 @@ class TestGCETestUtils(object):
         ]
 
         for feature_combination, expected_additional_tests in test_cases:
+            arch = feature_combination[0].upper()
+            boot_type = feature_combination[1]
+            shielded_vm = feature_combination[2]
+            nic = feature_combination[3]
+            confidential_compute = feature_combination[4]
             assert expected_additional_tests == \
                 get_additional_tests_for_instance(
-                    feature_combination=feature_combination,
+                    arch=arch,
+                    boot_type=boot_type,
+                    shielded_vm=shielded_vm,
+                    nic=nic,
+                    confidential_compute=confidential_compute,
                     additional_tests=additional_tests
                 )


### PR DESCRIPTION
### What does this PR do? Why are we making this change?
 Just chages the params for `get_additional_tests_for_instance` function to avoid unnecesary processing.
