### PR TITLE
Handle a mapping of catalog to entity id

### DIFF
--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -50,6 +50,27 @@ ec2_job_account = {
                    'optional. If supplied region, root_swap_ami and '
                    'subnet will override the account default values.'
 }
+ec2_entity = {
+    'type': 'object',
+    'properties': {
+        'entity_id': string_with_example(
+            '12345678-1234-1234-1234-012345678912',
+            description='The marketplace entity identifier. This is expected '
+                        'to be a UUID format ID.'
+        ),
+        'catalog': {
+            'type': 'string',
+            'enum': ['AWSMarketplace', 'AWSMarketplace-aws-eusc'],
+            'example': 'AWSMarketplace',
+            'description': 'The catalog related to the request.'
+        }
+    },
+    'additionalProperties': False,
+    'required': ['entity_id', 'catalog'],
+    'description': 'EC2 marketplace entity to use for the job. '
+                   'This is where the images will be published.'
+}
+
 
 ec2_job_message = copy.deepcopy(base_job_message)
 ec2_job_message['properties']['share_with'] = {
@@ -128,6 +149,18 @@ ec2_job_message['properties']['entity_id'] = string_with_example(
     description='The marketplace entity identifier. This is expected '
                 'to be a UUID format ID.'
 )
+ec2_job_message['properties']['entity_ids'] = {
+    'type': 'array',
+    'items': ec2_entity,
+    'minItems': 1,
+    'example': [
+        {
+            'entity_id': '12345678-1234-1234-1234-012345678912',
+            'catalog': 'AWSMarketplace'
+        }
+    ],
+    'description': 'The marketplace entity identifiers.'
+}
 ec2_job_message['properties']['version_title'] = string_with_example(
     'openSUSE Leap 15.3 - v202220114',
     description='The unique marketplace version title which will be '

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -117,7 +117,6 @@ def convert_account_dict(accounts):
 
 def validate_mp_fields(job_doc):
     mp_fields = [
-        'entity_id',
         'version_title',
         'release_notes',
         'access_role_arn',
@@ -138,6 +137,18 @@ def validate_mp_fields(job_doc):
             'image and are missing in the job doc: {fields}'.format(
                 fields=', '.join(missing_mp_fields)
             )
+        )
+
+    if not (job_doc.get('entity_id') or job_doc.get('entity_ids')):
+        raise MashJobException(
+            'One of entity_id or entity_ids is required to publish a '
+            'marketplace image and both are missing in the job doc.'
+        )
+
+    if job_doc.get('entity_id') and job_doc.get('entity_ids'):
+        raise MashJobException(
+            'Only one of entity_id or entity_ids can be provided to publish '
+            'a marketplace image and both are in the job doc.'
         )
 
 

--- a/mash/services/deprecate/ec2_mp_job.py
+++ b/mash/services/deprecate/ec2_mp_job.py
@@ -42,7 +42,6 @@ class EC2MPDeprecateJob(MashJob):
         """
         try:
             self.deprecate_regions = self.job_config['deprecate_regions']
-            self.entity_id = self.job_config['entity_id']
         except KeyError as error:
             raise MashDeprecateException(
                 'EC2 deprecate Jobs require a(n) {0} '
@@ -54,6 +53,21 @@ class EC2MPDeprecateJob(MashJob):
         self.old_cloud_image_name = self.job_config.get(
             'old_cloud_image_name'
         )
+
+        if self.job_config.get('entity_id'):
+            self.entity_ids = [
+                {
+                    'entity_id': self.job_config['entity_id'],
+                    'catalog': 'AWSMarketplace'
+                }
+            ]
+        elif self.job_config.get('entity_ids'):
+            self.entity_ids = self.job_config['entity_ids']
+        else:
+            raise MashDeprecateException(
+                'EC2 MP publish Jobs require either an entity_id '
+                'key or entity_ids key in the job doc.'
+            )
 
     def run_job(self):
         """
@@ -81,28 +95,35 @@ class EC2MPDeprecateJob(MashJob):
                 session.client('ec2'),
                 self.old_cloud_image_name
             )
-            delivery_option_id = get_image_delivery_option_id(
-                mp_client,
-                self.entity_id,
-                old_image['ImageId']
-            )
-            restrict_version_doc = create_restrict_version_change_doc(
-                entity_id=self.entity_id,
-                delivery_option_id=delivery_option_id
-            )
 
-            response = start_mp_change_set(
-                mp_client,
-                change_set=[
-                    self.status_msg.pop('add_version_doc'),
-                    restrict_version_doc
-                ]
-            )
-
-            self.status_msg['change_set_id'] = response.get('ChangeSetId')
-            self.log_callback.info(
-                'Marketplace change set submitted. Change set id: '
-                '{change_set}'.format(
-                    change_set=self.status_msg['change_set_id']
+            for entity in self.entity_ids:
+                entity_id = entity['entity_id']
+                delivery_option_id = get_image_delivery_option_id(
+                    mp_client,
+                    entity_id,
+                    old_image['ImageId']
                 )
-            )
+                restrict_version_doc = create_restrict_version_change_doc(
+                    entity_id=entity_id,
+                    delivery_option_id=delivery_option_id
+                )
+
+                response = start_mp_change_set(
+                    mp_client,
+                    change_set=[
+                        self.status_msg['add_version_docs'][entity_id],
+                        restrict_version_doc
+                    ],
+                    catalog=entity['catalog']
+                )
+
+                change_set_id = response.get('ChangeSetId')
+                self.status_msg['change_set_ids'][entity_id] = change_set_id
+                self.log_callback.info(
+                    'Marketplace change set submitted. Change set id: '
+                    '{change_set}'.format(
+                        change_set=change_set_id
+                    )
+                )
+
+            self.status_msg.pop('add_version_docs')

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -37,6 +37,7 @@ class EC2Job(BaseJob):
         self.use_root_swap = self.kwargs.get('use_root_swap', False)
         self.tpm_support = self.kwargs.get('tpm_support')
         self.entity_id = self.kwargs.get('entity_id')
+        self.entity_ids = self.kwargs.get('entity_ids')
         self.version_title = self.kwargs.get('version_title')
         self.release_notes = self.kwargs.get('release_notes')
         self.access_role_arn = self.kwargs.get('access_role_arn')
@@ -76,7 +77,8 @@ class EC2Job(BaseJob):
                 'deprecate_job': {
                     'cloud': 'ec2_mp',
                     'deprecate_regions': self.get_mp_deprecate_regions(),
-                    'entity_id': self.entity_id
+                    'entity_id': self.entity_id,
+                    'entity_ids': self.entity_ids
                 }
             }
         else:
@@ -121,6 +123,7 @@ class EC2Job(BaseJob):
                 'publish_job': {
                     'cloud': 'ec2_mp',
                     'entity_id': self.entity_id,
+                    'entity_ids': self.entity_ids,
                     'version_title': self.version_title,
                     'release_notes': self.release_notes,
                     'access_role_arn': self.access_role_arn,

--- a/mash/services/publish/ec2_mp_job.py
+++ b/mash/services/publish/ec2_mp_job.py
@@ -42,7 +42,6 @@ class EC2MPPublishJob(MashJob):
         """
         try:
             self.publish_regions = self.job_config['publish_regions']
-            self.entity_id = self.job_config['entity_id']
             self.version_title = self.job_config['version_title']
             self.access_role_arn = self.job_config['access_role_arn']
             self.release_notes = self.job_config['release_notes']
@@ -67,6 +66,21 @@ class EC2MPPublishJob(MashJob):
             False
         )
 
+        if self.job_config.get('entity_id'):
+            self.entity_ids = [
+                {
+                    'entity_id': self.job_config['entity_id'],
+                    'catalog': 'AWSMarketplace'
+                }
+            ]
+        elif self.job_config.get('entity_ids'):
+            self.entity_ids = self.job_config['entity_ids']
+        else:
+            raise MashPublishException(
+                'EC2 MP publish Jobs require either an entity_id '
+                'key or entity_ids key in the job doc.'
+            )
+
     def run_job(self):
         """
         Publish image and update status.
@@ -86,6 +100,8 @@ class EC2MPPublishJob(MashJob):
         for account, region in self.publish_regions.items():
             creds = self.credentials[account]
             ami_id = self.status_msg['source_regions'][region]
+            self.status_msg['change_set_ids'] = {}
+            self.status_msg['add_version_docs'] = {}
 
             self.share_image(
                 region,
@@ -93,40 +109,44 @@ class EC2MPPublishJob(MashJob):
                 creds['secret_access_key']
             )
 
-            change_doc = create_add_version_change_doc(
-                self.entity_id,
-                self.version_title,
-                ami_id,
-                self.access_role_arn,
-                self.release_notes,
-                self.os_name,
-                self.os_version,
-                self.usage_instructions,
-                self.recommended_instance_type,
-                self.ssh_user
-            )
-
-            if self.submit_change_request:
-                session = get_session(
-                    creds['access_key_id'],
-                    creds['secret_access_key'],
-                    region
+            for entity in self.entity_ids:
+                entity_id = entity['entity_id']
+                change_doc = create_add_version_change_doc(
+                    entity_id,
+                    self.version_title,
+                    ami_id,
+                    self.access_role_arn,
+                    self.release_notes,
+                    self.os_name,
+                    self.os_version,
+                    self.usage_instructions,
+                    self.recommended_instance_type,
+                    self.ssh_user
                 )
 
-                response = start_mp_change_set(
-                    session.client('marketplace-catalog'),
-                    change_set=[change_doc]
-                )
-
-                self.status_msg['change_set_id'] = response.get('ChangeSetId')
-                self.log_callback.info(
-                    'Marketplace change set submitted. Change set id: '
-                    '{change_set}'.format(
-                        change_set=self.status_msg['change_set_id']
+                if self.submit_change_request:
+                    session = get_session(
+                        creds['access_key_id'],
+                        creds['secret_access_key'],
+                        region
                     )
-                )
-            else:
-                self.status_msg['add_version_doc'] = change_doc
+
+                    response = start_mp_change_set(
+                        session.client('marketplace-catalog'),
+                        change_set=[change_doc],
+                        catalog=entity['catalog']
+                    )
+
+                    change_set_id = response.get('ChangeSetId')
+                    self.status_msg['change_set_ids'][entity_id] = change_set_id
+                    self.log_callback.info(
+                        'Marketplace change set submitted. Change set id: '
+                        '{change_set}'.format(
+                            change_set=change_set_id
+                        )
+                    )
+                else:
+                    self.status_msg['add_version_docs'][entity_id] = change_doc
 
     def share_image(self, region, access_key_id, secret_access_key):
         publish = EC2PublishImage(

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -251,8 +251,26 @@ def test_validate_ec2_job(
         validate_ec2_job(job_doc)
 
 
+@patch('mash.services.api.v1.utils.jobs.ec2.get_ec2_account')
+@patch('mash.services.api.v1.utils.jobs.ec2.get_ec2_helper_images')
 @patch.object(LocalProxy, '_get_current_object')
-def test_validate_mp_fields(mock_get_current_obj):
+def test_validate_mp_fields(
+    mock_get_current_obj,
+    mock_get_helper_images,
+    mock_get_ec2_account
+):
+    account = {
+        'region': 'us-east-100',
+        'name': 'acnt1',
+        'partition': 'aws',
+        'additional_regions': [
+            {
+                'name': 'us-east-100',
+                'helper_image': 'ami-987'
+            }
+        ]
+    }
+    mock_get_ec2_account.return_value = account
     app = Mock()
     app.config = {
         'SERVICE_NAMES': [
@@ -267,6 +285,7 @@ def test_validate_mp_fields(mock_get_current_obj):
         ]
     }
     mock_get_current_obj.return_value = app
+    mock_get_helper_images.return_value = {'us-east-99': 'ami-789'}
 
     job_doc = {
         'last_service': 'publish',
@@ -279,3 +298,68 @@ def test_validate_mp_fields(mock_get_current_obj):
 
     with raises(MashJobException):
         validate_ec2_job(job_doc)
+
+    # Validate exception raised with no entity field
+
+    job_doc = {
+        'last_service': 'publish',
+        'requesting_user': '1',
+        'cloud_account': 'acnt1',
+        'cloud_image_name': 'Test OEM Image',
+        'image_description': 'Description of an image',
+        'publish_in_marketplace': True,
+        'version_title': 'Version 123',
+        'access_role_arn': 'ar:123:aws',
+        'release_notes': 'Upgrade with zypper',
+        'os_name': 'SLES',
+        'os_version': '15SP5',
+        'usage_instructions': 'Login via SSH',
+        'recommended_instance_type': 't2.micro'
+    }
+
+    with raises(MashJobException):
+        validate_ec2_job(job_doc)
+
+    # Validate exception raised with both entity fields
+
+    job_doc = {
+        'last_service': 'publish',
+        'requesting_user': '1',
+        'cloud_account': 'acnt1',
+        'cloud_image_name': 'Test OEM Image',
+        'image_description': 'Description of an image',
+        'publish_in_marketplace': True,
+        'version_title': 'Version 123',
+        'access_role_arn': 'ar:123:aws',
+        'release_notes': 'Upgrade with zypper',
+        'os_name': 'SLES',
+        'os_version': '15SP5',
+        'usage_instructions': 'Login via SSH',
+        'recommended_instance_type': 't2.micro',
+        'entity_id': '213',
+        'entity_ids': {'catalog': 'AWSMarketplace', 'entity_id': '231'},
+    }
+
+    with raises(MashJobException):
+        validate_ec2_job(job_doc)
+
+    # Valid MP job
+
+    job_doc = {
+        'last_service': 'publish',
+        'requesting_user': '1',
+        'cloud_account': 'acnt1',
+        'cloud_image_name': 'Test OEM Image',
+        'image_description': 'Description of an image',
+        'publish_in_marketplace': True,
+        'version_title': 'Version 123',
+        'access_role_arn': 'ar:123:aws',
+        'release_notes': 'Upgrade with zypper',
+        'os_name': 'SLES',
+        'os_version': '15SP5',
+        'usage_instructions': 'Login via SSH',
+        'recommended_instance_type': 't2.micro',
+        'entity_id': '213'
+    }
+
+    validate_ec2_job(job_doc)

--- a/test/unit/services/deprecate/ec2_mp_job_test.py
+++ b/test/unit/services/deprecate/ec2_mp_job_test.py
@@ -29,14 +29,17 @@ class TestEC2MPDeprecateJob(object):
                 'ssh_private_key': 'key123'
             }
         }
-        self.job.status_msg['add_version_doc'] = {
-            'ChangeType': 'AddDeliveryOptions',
-            'Entity': {
-                'Type': 'AmiProduct@1.0',
-                'Identifier': '123'
-            },
-            'Details': '{"new": "version"}'
+        self.job.status_msg['add_version_docs'] = {
+            '123': {
+                'ChangeType': 'AddDeliveryOptions',
+                'Entity': {
+                    'Type': 'AmiProduct@1.0',
+                    'Identifier': '123'
+                },
+                'Details': '{"new": "version"}'
+            }
         }
+        self.job.status_msg['change_set_ids'] = {}
         self.job._log_callback = Mock()
 
     def test_deprecate_ec2_missing_key(self):
@@ -86,11 +89,12 @@ class TestEC2MPDeprecateJob(object):
                     },
                     'Details': '{"DeliveryOptionIds": ["1234567-12345-23456-23456"]}'
                 }
-            ]
+            ],
+            catalog='AWSMarketplace'
         )
 
         assert self.job.status == 'success'
-        assert self.job.status_msg['change_set_id'] == '123'
+        assert self.job.status_msg['change_set_ids']['123'] == '123'
 
     @patch('mash.services.deprecate.ec2_mp_job.get_image')
     def test_deprecate_exception(


### PR DESCRIPTION
This allows for a configurable catalog per entity id. It allows allows for updating multiple entities in the same account with the same image.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
