### PR TITLE
Add image tags option for ec2 jobs

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -18,7 +18,7 @@ PyJWT
 APScheduler
 python-dateutil>=2.6.0
 amqpstorm
-ec2imgutils>=10.0.3
+ec2imgutils>=10.0.5
 img-proof>=7.14.0
 requests
 obs-img-utils>=1.12.0

--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -201,6 +201,12 @@ ec2_job_message['properties']['upload_wait_count'] = {
     'description': 'Wait N-number of times for AWS operation timeout '
                    '(Default is 3). The wait time is 600 seconds each count.'
 }
+ec2_job_message['properties']['image_tags'] = string_with_example(
+    '[{"Key": "date", "Value": "20220202"}]',
+    description='A valid json list of tags as dictionaries. Each dictionary '
+                'requires a "Key" and "Value" representing the key and '
+                'value of the tag to apply to the image.',
+)
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -17,6 +17,7 @@
 #
 
 import copy
+import json
 
 from flask import current_app
 
@@ -160,6 +161,14 @@ def validate_ec2_job(job_doc):
             'NitroTPM support requires a UEFI compatible image. '
             'Ensure "uefi" is included in "boot_firmware" list.'
         )
+
+    if job_doc.get('image_tags'):
+        try:
+            json.loads(job_doc['image_tags'])
+        except json.decoder.JSONDecodeError:
+            raise MashJobException(
+                'The image tags option is required to be a valid json string.'
+            )
 
     job_doc = validate_job(job_doc)
 

--- a/mash/services/create/ec2_job.py
+++ b/mash/services/create/ec2_job.py
@@ -76,6 +76,7 @@ class EC2CreateJob(MashJob):
         self.imds_version = self.job_config.get('imds_version', '')
         self.root_volume_size = self.job_config.get('root_volume_size', 10)
         self.upload_wait_count = self.job_config.get('upload_wait_count', 3)
+        self.image_tags = self.job_config.get('image_tags')
 
         # EC2 images only support one firmware
         self.boot_firmware = self.boot_firmware[0]
@@ -134,7 +135,8 @@ class EC2CreateJob(MashJob):
             'secret_key': None,
             'billing_codes': None,
             'log_callback': self.log_callback,
-            'boot_mode': self.boot_firmware
+            'boot_mode': self.boot_firmware,
+            'image_tags': self.image_tags
         }
 
         if self.tpm_support:

--- a/mash/services/jobcreator/ec2_job.py
+++ b/mash/services/jobcreator/ec2_job.py
@@ -55,6 +55,7 @@ class EC2Job(BaseJob):
         self.imds_version = self.kwargs.get('imds_version', '')
         self.root_volume_size = self.kwargs.get('root_volume_size', 10)
         self.upload_wait_count = self.kwargs.get('upload_wait_count', 3)
+        self.image_tags = self.kwargs.get('image_tags')
 
     def _get_target_regions_list(self):
         """
@@ -288,7 +289,8 @@ class EC2Job(BaseJob):
                 'boot_firmware': self.boot_firmware,
                 'launch_inst_type': self.launch_inst_type,
                 'root_volume_size': self.root_volume_size,
-                'upload_wait_count': self.upload_wait_count
+                'upload_wait_count': self.upload_wait_count,
+                'image_tags': self.image_tags
             }
         }
         create_message['create_job'].update(self.base_message)

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -44,7 +44,7 @@ BuildRequires:  %{pythons}-PyJWT
 BuildRequires:  %{pythons}-amqpstorm >= 2.4.0
 BuildRequires:  %{pythons}-APScheduler >= 3.3.1
 BuildRequires:  %{pythons}-python-dateutil >= 2.6.0
-BuildRequires:  python-ec2imgutils >= 9.0.3
+BuildRequires:  python-ec2imgutils >= 10.0.5
 BuildRequires:  python-img-proof >= 7.14.0
 BuildRequires:  python-img-proof-tests >= 7.14.0
 BuildRequires:  %{pythons}-Flask
@@ -70,7 +70,7 @@ Requires:       %{pythons}-PyJWT
 Requires:       %{pythons}-amqpstorm >= 2.4.0
 Requires:       %{pythons}-APScheduler >= 3.3.1
 Requires:       %{pythons}-python-dateutil >= 2.6.0
-Requires:       python-ec2imgutils >= 9.0.3
+Requires:       python-ec2imgutils >= 10.0.5
 Requires:       python-img-proof >= 7.14.0
 Requires:       python-img-proof-tests >= 7.14.0
 Requires:       %{pythons}-Flask

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -235,8 +235,32 @@ def test_validate_ec2_job(
     }
 
     result = validate_ec2_job(job_doc)
-
     assert 'cloud_account' not in result
+
+    # Test doc with valid image tags
+    job_doc = {
+        'last_service': 'testing',
+        'requesting_user': '1',
+        'cloud_account': 'acnt1',
+        'cloud_image_name': 'Test OEM Image',
+        'image_description': 'Description of an image',
+        'image_tags': '[{"Key": "key", "Value": "value"}]'
+    }
+
+    result = validate_ec2_job(job_doc)
+
+    # Test doc with invalid image tags
+    job_doc = {
+        'last_service': 'testing',
+        'requesting_user': '1',
+        'cloud_account': 'acnt1',
+        'cloud_image_name': 'Test OEM Image',
+        'image_description': 'Description of an image',
+        'image_tags': 'Image tags'
+    }
+
+    with raises(MashJobException):
+        result = validate_ec2_job(job_doc)
 
     # Test doc with TPM and no uefi
     job_doc = {

--- a/test/unit/services/create/ec2_job_test.py
+++ b/test/unit/services/create/ec2_job_test.py
@@ -156,6 +156,7 @@ class TestAmazonCreateJob(object):
             vpc_subnet_id='subnet-123456789',
             wait_count=3,
             log_callback=self.job._log_callback,
+            image_tags=None,
             tpm_support='v2.0',
             boot_mode='uefi-preferred',
             imds_support='v2.0',


### PR DESCRIPTION
This allows the inclusion of a list of image tags to be added to the ec2 image at creation.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
