### PR TITLE
Fix bug in image tags functionality

### DIFF
--- a/mash/services/api/v1/schema/jobs/ec2.py
+++ b/mash/services/api/v1/schema/jobs/ec2.py
@@ -201,12 +201,32 @@ ec2_job_message['properties']['upload_wait_count'] = {
     'description': 'Wait N-number of times for AWS operation timeout '
                    '(Default is 3). The wait time is 600 seconds each count.'
 }
-ec2_job_message['properties']['image_tags'] = string_with_example(
-    '[{"Key": "date", "Value": "20220202"}]',
-    description='A valid json list of tags as dictionaries. Each dictionary '
-                'requires a "Key" and "Value" representing the key and '
-                'value of the tag to apply to the image.',
-)
+image_tag = {
+    'type': 'object',
+    'properties': {
+        'Key': string_with_example(
+            'date',
+            description='Name of cloud account as associated with the mash '
+                        'user account.'
+        ),
+        'Value': string_with_example(
+            '20220202',
+            description='Region to use for initial image creation.'
+        )
+    },
+    'additionalProperties': False,
+    'required': ['Key', 'Value'],
+    'description': 'A valid key value tag object. Each tag '
+                   'requires a "Key" and "Value" representing the key and '
+                   'value of the tag to apply to the image.'
+}
+ec2_job_message['properties']['image_tags'] = {
+    'type': 'array',
+    'items': image_tag,
+    'minItems': 1,
+    'example': [{'Key': 'date', 'Value': '20220202'}],
+    'description': 'A list of image tags to apply to the image at creation.'
+}
 ec2_job_message['anyOf'] = [
     {'required': ['cloud_account']},
     {'required': ['cloud_accounts']},

--- a/mash/services/api/v1/utils/jobs/ec2.py
+++ b/mash/services/api/v1/utils/jobs/ec2.py
@@ -17,7 +17,6 @@
 #
 
 import copy
-import json
 
 from flask import current_app
 
@@ -161,14 +160,6 @@ def validate_ec2_job(job_doc):
             'NitroTPM support requires a UEFI compatible image. '
             'Ensure "uefi" is included in "boot_firmware" list.'
         )
-
-    if job_doc.get('image_tags'):
-        try:
-            json.loads(job_doc['image_tags'])
-        except json.decoder.JSONDecodeError:
-            raise MashJobException(
-                'The image tags option is required to be a valid json string.'
-            )
 
     job_doc = validate_job(job_doc)
 

--- a/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
+++ b/test/unit/services/api/v1/utils/jobs/ec2_job_utils_test.py
@@ -244,23 +244,10 @@ def test_validate_ec2_job(
         'cloud_account': 'acnt1',
         'cloud_image_name': 'Test OEM Image',
         'image_description': 'Description of an image',
-        'image_tags': '[{"Key": "key", "Value": "value"}]'
+        'image_tags': [{"Key": "key", "Value": "value"}]
     }
 
     result = validate_ec2_job(job_doc)
-
-    # Test doc with invalid image tags
-    job_doc = {
-        'last_service': 'testing',
-        'requesting_user': '1',
-        'cloud_account': 'acnt1',
-        'cloud_image_name': 'Test OEM Image',
-        'image_description': 'Description of an image',
-        'image_tags': 'Image tags'
-    }
-
-    with raises(MashJobException):
-        result = validate_ec2_job(job_doc)
 
     # Test doc with TPM and no uefi
     job_doc = {


### PR DESCRIPTION
Mash can accept the image tags as a dictionary object which allows for better data validation.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
