### PR TITLE
Add a flag to publish from a SIG

### DIFF
--- a/mash/services/api/v1/schema/jobs/azure.py
+++ b/mash/services/api/v1/schema/jobs/azure.py
@@ -104,6 +104,13 @@ azure_job_message['properties']['gallery_resource_group'] = string_with_example(
                 'gallery is found. By default the source_resource_group '
                 'is used.'
 )
+azure_job_message['properties']['publish_from_sig'] = {
+    'type': 'boolean',
+    'example': True,
+    'description': 'If True the image version will be published to the '
+                   'offer in the Partner Center from the provided shared '
+                   'image gallery.'
+}
 
 azure_job_message['required'].append('cloud_account')
 azure_job_message['properties']['image']['example'] = \

--- a/mash/services/jobcreator/azure_job.py
+++ b/mash/services/jobcreator/azure_job.py
@@ -49,6 +49,7 @@ class AzureJob(BaseJob):
         self.gallery_name = self.kwargs.get('gallery_name')
         self.gallery_resource_group = self.kwargs.get('gallery_resource_group')
         self.partner_center_account = self.kwargs.get('partner_center_account')
+        self.publish_from_sig = self.kwargs.get('publish_from_sig', False)
 
     def get_deprecate_message(self):
         """
@@ -81,7 +82,7 @@ class AzureJob(BaseJob):
             publish_message['publish_job']['generation_id'] = \
                 self.generation_id
 
-        if self.gallery_name:
+        if self.gallery_name and self.publish_from_sig:
             publish_message['publish_job']['account'] = \
                 self.partner_center_account or self.cloud_account
             publish_message['publish_job']['cloud'] = 'azure_sig'

--- a/test/unit/services/jobcreator/service_test.py
+++ b/test/unit/services/jobcreator/service_test.py
@@ -300,6 +300,7 @@ class TestJobCreatorService(object):
             job = json.load(job_doc)
 
         job['notification_email'] = 'test@fake.com'
+        job['publish_from_sig'] = True
         message = MagicMock()
         message.body = json.dumps(job)
         self.jobcreator._handle_service_message(message)


### PR DESCRIPTION
Make the publish from SIG workflow optional for Azure images. Core VM types do not have the SIG type in schema def.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
