### PR TITLE
Add labels option to GCE job creation

### DIFF
--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -27,5 +27,5 @@ werkzeug
 aliyun-img-utils>=1.4.0
 azure-img-utils>=2.6.0
 jmespath
-gceimgutils>=1.3.0
+gceimgutils>=1.5.0
 aws-mp-utils

--- a/mash/services/api/v1/schema/jobs/gce.py
+++ b/mash/services/api/v1/schema/jobs/gce.py
@@ -52,6 +52,14 @@ gce_job_message['properties']['licenses'] = {
     'example': ['projects/project-123/global/licenses/123'],
     'description': 'A list of applicable license URIs.'
 }
+gce_job_message['properties']['labels'] = {
+    'type': 'object',
+    'additionalProperties': {'type': 'string'},
+    'example': {'key1': 'value1', 'key2': 'value2'},
+    'description': 'A dictionary of key/value label pairs to apply to '
+                   'the image when creating it. Keys and values must be '
+                   'strings.'
+}
 gce_job_message['properties']['test_fallback_regions'] = {
     'type': 'array',
     'items': string_with_example('us-west1-a'),

--- a/mash/services/create/gce_job.py
+++ b/mash/services/create/gce_job.py
@@ -54,6 +54,7 @@ class GCECreateJob(MashJob):
         self.licenses = self.job_config.get('licenses')
         self.arch = self.job_config.get('cloud_architecture', 'x86_64')
         self.skip_rollout = self.job_config.get('skip_rollout', False)
+        self.labels = self.job_config.get('labels')
 
         if self.arch == 'aarch64':
             self.arch = 'arm64'
@@ -111,6 +112,7 @@ class GCECreateJob(MashJob):
             family=self.family,
             guest_os_features=self.guest_os_features,
             licenses=self.licenses,
+            labels=self.labels,
             credentials_info=credentials,
             project=project,
             log_callback=self.log_callback

--- a/mash/services/jobcreator/gce_job.py
+++ b/mash/services/jobcreator/gce_job.py
@@ -50,6 +50,7 @@ class GCEJob(BaseJob):
         self.licenses = self.kwargs.get('licenses', [])
         self.image_project = self.kwargs.get('image_project')
         self.skip_rollout = self.kwargs.get('skip_rollout', False)
+        self.labels = self.kwargs.get('labels')
 
     def get_deprecate_message(self):
         """
@@ -177,7 +178,8 @@ class GCEJob(BaseJob):
                 'bucket': self.bucket,
                 'region': self.region,
                 'skip_rollout': self.skip_rollout,
-                'cloud_architecture': self.cloud_architecture
+                'cloud_architecture': self.cloud_architecture,
+                'labels': self.labels
             }
         }
         create_message['create_job'].update(self.base_message)

--- a/package/mash.spec
+++ b/package/mash.spec
@@ -55,7 +55,7 @@ BuildRequires:  %{pythons}-flask-jwt-extended
 BuildRequires:  %{pythons}-requests
 BuildRequires:  python-obs-img-utils >= 1.12.0
 BuildRequires:  %{pythons}-oci-sdk
-BuildRequires:  python-gceimgutils >= 1.3.0
+BuildRequires:  python-gceimgutils >= 1.5.0
 BuildRequires:  python-aliyun-img-utils >= 1.4.0
 BuildRequires:  python-azure-img-utils >= 2.6.0
 BuildRequires:  python-aws-mp-utils
@@ -81,7 +81,7 @@ Requires:       %{pythons}-flask-jwt-extended
 Requires:       %{pythons}-requests
 Requires:       python-obs-img-utils >= 1.12.0
 Requires:       %{pythons}-oci-sdk
-Requires:       python-gceimgutils >= 1.3.0
+Requires:       python-gceimgutils >= 1.5.0
 Requires:       python-aliyun-img-utils >= 1.4.0
 Requires:       python-azure-img-utils >= 2.6.0
 Requires:       python-aws-mp-utils

--- a/test/data/gce_job.json
+++ b/test/data/gce_job.json
@@ -24,6 +24,7 @@
   "notify": true,
   "guest_os_features": ["UEFI_COMPATIBLE"],
   "licenses": ["projects/project-123/global/licenses/123"],
+  "labels": {"key1": "value1", "key2": "value2"},
   "raw_image_upload_type": "s3bucket",
   "raw_image_upload_account": "account",
   "raw_image_upload_location": "location",

--- a/test/unit/services/create/gce_job_test.py
+++ b/test/unit/services/create/gce_job_test.py
@@ -41,6 +41,7 @@ class TestGCECreateJob(object):
             'family': 'sles-12',
             'guest_os_features': ['UEFI_COMPATIBLE'],
             'licenses': ['projects/project-123/global/licenses/123'],
+            'labels': {'env': 'prod'},
             'region': 'us-west1-a',
             'account': 'test',
             'bucket': 'images',
@@ -100,6 +101,7 @@ class TestGCECreateJob(object):
             'sles-12-sp4-v20180909'
         )
         creator.create_image.assert_called_once_with()
+        assert mock_creator.call_args.kwargs['labels'] == {'env': 'prod'}
 
     @patch('mash.services.create.gce_job.get_credentials')
     @patch('mash.services.create.gce_job.get_image')
@@ -144,3 +146,41 @@ class TestGCECreateJob(object):
             'sles-15-sp4-v20210731'
         )
         creator.create_image.assert_called_once_with()
+
+    @patch('mash.services.create.gce_job.get_credentials')
+    @patch('mash.services.create.gce_job.get_image')
+    @patch('mash.services.create.gce_job.GCECreateImage')
+    @patch('mash.services.create.gce_job.GCERemoveImage')
+    @patch('mash.services.create.gce_job.get_images_client')
+    @patch('builtins.open')
+    def test_create_no_labels(
+        self,
+        mock_open,
+        mock_get_client,
+        mock_remover,
+        mock_creator,
+        mock_get_image,
+        mock_get_credentials
+    ):
+        del self.complete_job_doc['labels']
+        job = GCECreateJob(self.complete_job_doc, self.config)
+        job._log_callback = Mock()
+        job.credentials = self.credentials
+        open_handle = MagicMock()
+        open_handle.__enter__.return_value = open_handle
+        mock_open.return_value = open_handle
+
+        remover = MagicMock()
+        creator = MagicMock()
+
+        mock_remover.return_value = remover
+        mock_creator.return_value = creator
+
+        compute_client = Mock()
+        mock_get_client.return_value = compute_client
+
+        job.status_msg['cloud_image_name'] = 'sles-12-sp4-v20180909'
+        job.status_msg['object_name'] = 'sles-12-sp4-v20180909.tar.gz'
+        job.run_job()
+
+        assert mock_creator.call_args.kwargs['labels'] is None

--- a/test/unit/services/jobcreator/gce_job_test.py
+++ b/test/unit/services/jobcreator/gce_job_test.py
@@ -80,3 +80,45 @@ def test_gce_job_test_message(mock_init):
 
     test_message = json.loads(job.get_test_message())
     assert test_message['test_job']['cleanup_images'] is True
+
+
+@patch.object(GCEJob, '__init__')
+def test_gce_job_create_message(mock_init):
+    mock_init.return_value = None
+
+    job = GCEJob({
+        'job_id': '123',
+        'cloud': 'gce',
+        'requesting_user': 'test-user',
+        'last_service': 'create',
+        'utctime': 'now',
+        'image': 'test-image',
+        'cloud_image_name': 'test-cloud-image',
+        'image_description': 'image description',
+        'distro': 'sles',
+        'download_url': 'https://download.here'
+    })
+    job.kwargs = {
+        'cloud_account': 'acnt1',
+        'bucket': 'images',
+        'cloud': 'gce',
+        'region': 'westus',
+        'testing_account': None,
+        'labels': {'foo': 'bar'}
+    }
+    job.cloud = 'gce'
+    job.image_description = 'image description'
+    job.cloud_architecture = 'x86_64'
+    job.base_message = {}
+
+    job.post_init()
+
+    create_message = json.loads(job.get_create_message())
+    assert create_message['create_job']['labels'] == {'foo': 'bar'}
+
+    # Default labels to None when not provided
+    del job.kwargs['labels']
+    job.post_init()
+
+    create_message = json.loads(job.get_create_message())
+    assert create_message['create_job']['labels'] is None


### PR DESCRIPTION
Allow specifying a dictionary of key/value label pairs that are applied to the image when creating it in GCE. The labels are passed through from the API schema to the jobcreator and on to GCECreateImage in the create service.

### What does this PR do? Why are we making this change?


### How will these changes be tested?


### How will this change be deployed? Any special considerations?


### Additional Information
